### PR TITLE
Fix problems finding dependencies

### DIFF
--- a/jarplant-lib/src/main/java/io/github/w1th4d/jarplant/ImplantHandlerImpl.java
+++ b/jarplant-lib/src/main/java/io/github/w1th4d/jarplant/ImplantHandlerImpl.java
@@ -4,6 +4,7 @@ import javassist.bytecode.*;
 
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -39,84 +40,91 @@ public class ImplantHandlerImpl implements ImplantHandler {
         return new ImplantHandlerImpl(bytes, className, availableConfig, Collections.emptyMap());
     }
 
-    // Finds the class file using some weird Java quirks
-    public static ImplantHandler findAndCreateFor(Class<?> clazz) throws ClassNotFoundException, IOException, ImplantException {
-        CodeSource codeSource = clazz.getProtectionDomain().getCodeSource();
-        if (codeSource == null) {
-            // Can't find oneself
-            throw new ClassNotFoundException("Can't determine the path to the class file");
+    public static ImplantHandler createFromJar(Path jarFilePath, ClassName nameOfPayloadBearingClass) throws IOException, ClassNotFoundException, ImplantException {
+        if (!looksLikeAJarFile(jarFilePath)) {
+            throw new IOException("Does not looks like a JAR file: " + jarFilePath);
         }
-        Path sourcePath = Path.of(codeSource.getLocation().getPath());
-
-        return findAndCreateFor(sourcePath, ClassName.of(clazz));
+        return findAndCreateFor(jarFilePath, nameOfPayloadBearingClass);
     }
 
-    // This method may be used when extracting the implant from another place than self
-    public static ImplantHandler findAndCreateFor(Path path, ClassName className) throws ClassNotFoundException, IOException, ImplantException {
-        ImplantHandler ret;
-        if (Files.isDirectory(path)) {
-            ret = findAndReadFromDirectory(path, className);
+    private static boolean looksLikeAJarFile(Path path) throws IOException {
+        JarFile openAttempt = new JarFile(path.toFile());
+        openAttempt.close();
+        return true;
+    }
+
+    static Path getSourcePathFor(ClassName className) throws ClassNotFoundException, FileNotFoundException {
+        String theFullName = className.getFullClassName();
+        Class<?> classFromFullName = Class.forName(theFullName);
+        return getSourcePathFor(classFromFullName);
+    }
+
+    static Path getSourcePathFor(Class<?> clazz) throws FileNotFoundException {
+        CodeSource codeSource = clazz.getProtectionDomain().getCodeSource();
+        if (codeSource == null) {
+            // This class is likely a part of the SDK (or something else we can't find)
+            throw new FileNotFoundException("Cannot find code source path for '" + clazz.getName() + "'.");
+        }
+
+        return Path.of(codeSource.getLocation().getPath());
+    }
+
+    private static ThrowingFunction<ClassName, Optional<byte[]>, IOException> getReaderFunctionFor(Path codePath) {
+        ThrowingFunction<ClassName, Optional<byte[]>, IOException> ret;
+
+        if (Files.isDirectory(codePath)) {
+            // Lambda function for reading a class from this directory
+            ret = (name) -> {
+                Path sourcePath = Path.of(codePath.toString(), name.getClassFilePath());
+                if (!Files.exists(sourcePath)) {
+                    return Optional.empty();
+                }
+
+                return Optional.of(Files.readAllBytes(sourcePath));
+            };
         } else {
-            ret = findAndReadFromJar(path, className);
+            // Lambda function for reading a class from this JAR
+            ret = (name) -> {
+                byte[] entryBytes;
+
+                try (JarFile jarFile = new JarFile(codePath.toFile())) {
+                    ZipEntry entry = jarFile.getEntry(name.getClassFilePath());
+                    if (entry == null) {
+                        return Optional.empty();
+                    }
+
+                    entryBytes = jarFile.getInputStream(entry).readAllBytes();
+                }
+
+                return Optional.of(entryBytes);
+            };
         }
 
         return ret;
     }
 
-    private static ImplantHandler findAndReadFromDirectory(Path directory, ClassName implantClassName) throws ClassNotFoundException, IOException {
-        // Lambda function for reading a class from this directory
-        ThrowingFunction<ClassName, Optional<byte[]>, IOException> readEntryFromDirectory = (name) -> {
-            Path sourcePath = Path.of(directory.toString(), name.getClassFilePath());
-            if (!Files.exists(sourcePath)) {
-                return Optional.empty();
-            }
+    public static ImplantHandler findAndCreateFor(Class<?> clazz) throws ClassNotFoundException, IOException, ImplantException {
+        Path sourcePath = getSourcePathFor(clazz);
 
-            return Optional.of(Files.readAllBytes(sourcePath));
-        };
+        return findAndCreateFor(sourcePath, ClassName.of(clazz));
+    }
 
-        // Read the implant class
-        Optional<byte[]> implantClassBytes = readEntryFromDirectory.apply(implantClassName);
-        if (implantClassBytes.isEmpty()) {
-            throw new ClassNotFoundException(directory.resolve(implantClassName.getClassFilePath()).toString());
+    public static ImplantHandler findAndCreateFor(Path path, ClassName className) throws ClassNotFoundException, IOException, ImplantException {
+        ThrowingFunction<ClassName, Optional<byte[]>, IOException> classReaderFunction = getReaderFunctionFor(path);
+
+        Optional<byte[]> rawClassDataMaybe = classReaderFunction.apply(className);
+        if (rawClassDataMaybe.isEmpty()) {
+            throw new ClassNotFoundException("Cannot figure out how to find class '" + className + "'.");
         }
 
         // Read its available config properties
-        ClassFile sample = readClassFile(implantClassBytes.get());
+        ClassFile sample = readClassFile(rawClassDataMaybe.get());
         Map<String, ConfDataType> availableConfig = readImplantConfig(sample);
 
-        // Read its dependencies using the lambda specific for class directories
-        Map<ClassName, byte[]> dependencies = readAllDependencies(implantClassName, readEntryFromDirectory);
+        // Read its dependencies
+        Map<ClassName, byte[]> dependencies = readAllDependencies(className, classReaderFunction);
 
-        return new ImplantHandlerImpl(implantClassBytes.get(), implantClassName, availableConfig, dependencies);
-    }
-
-    private static ImplantHandler findAndReadFromJar(Path jarFilePath, ClassName implantClassName) throws ClassNotFoundException, IOException {
-        try (JarFile jarFile = new JarFile(jarFilePath.toFile())) {
-            // Lambda function for reading a class from this JAR
-            ThrowingFunction<ClassName, Optional<byte[]>, IOException> readEntryFromJar = (name) -> {
-                ZipEntry entry = jarFile.getEntry(name.getClassFilePath());
-                if (entry == null) {
-                    return Optional.empty();
-                }
-
-                return Optional.of(jarFile.getInputStream(entry).readAllBytes());
-            };
-
-            // Read the implant class
-            Optional<byte[]> implantClassBytes = readEntryFromJar.apply(implantClassName);
-            if (implantClassBytes.isEmpty()) {
-                throw new ClassNotFoundException("File '" + implantClassName.getClassFilePath() + "' in JAR '" + jarFilePath + "'");
-            }
-
-            // Read its available config properties
-            ClassFile sample = readClassFile(implantClassBytes.get());
-            Map<String, ConfDataType> availableConfig = readImplantConfig(sample);
-
-            // Read its dependencies using the lambda specific for JARs
-            Map<ClassName, byte[]> dependencies = readAllDependencies(implantClassName, readEntryFromJar);
-
-            return new ImplantHandlerImpl(implantClassBytes.get(), implantClassName, availableConfig, dependencies);
-        }
+        return new ImplantHandlerImpl(rawClassDataMaybe.get(), className, availableConfig, dependencies);
     }
 
     @Override
@@ -317,25 +325,70 @@ public class ImplantHandlerImpl implements ImplantHandler {
             } catch (ClassNameException e) {
                 continue;
             }
+
             if (classReferenceName.equals(thisClassName)) {
                 // Don't go recursing on ourselves again
                 continue;
             }
 
             if (accumulator.containsKey(classReferenceName)) {
-                // This dependency is already noted (don't get lost in circular dependencies)
+                // This dependency is already noted
                 continue;
             }
 
-            Optional<byte[]> classRawData = classDataReader.apply(classReferenceName);
-            if (classRawData.isEmpty()) {
-                continue;
+            /*
+             * First try to read the class from the code source path that's already given.
+             * This works if the dependency is a class defined by the implant project itself.
+             */
+            Optional<byte[]> classRefDataMaybe = classDataReader.apply(classReferenceName);
+            if (classRefDataMaybe.isPresent()) {
+                // Found it! Add it and keep recursing down on any sub-dependencies it may have.
+                accumulator.put(classReferenceName, classRefDataMaybe.get());
+                readAllDependencies(classReferenceName, classDataReader, accumulator);
+            } else {
+                /*
+                 * The referenced dependency class is not bundled with the implant.
+                 * Go look for it on the classpath of this JVM.
+                 * This may sound weird, but it's a common scenario when running in the context of an IDE, Maven or
+                 * unit test, and it's using external dependencies (aka libraries).
+                 */
+                Path sourcePath;
+                try {
+                    sourcePath = getSourcePathFor(classReferenceName);
+                } catch (ClassNotFoundException e) {
+                    throw new RuntimeException("Cannot get code source path for '" + classReferenceName + "'.", e);
+                } catch (FileNotFoundException e) {
+                    /*
+                     * The code source for this dependency is still unknown.
+                     * This is typically the case for classes in the SDK.
+                     * Skip this and assume it's provided by the runtime environment when the implant runs.
+                     */
+                    log.fine("Assuming that '" + classReferenceName + "' is part of the SDK or otherwise provided during runtime. Skipping.");
+                    continue;
+                }
+
+                // Get a new class reader function specific for this new code source path and use that instead.
+                ThrowingFunction<ClassName, Optional<byte[]>, IOException> classRefSourcePathReader = getReaderFunctionFor(sourcePath);
+                classRefDataMaybe = classRefSourcePathReader.apply(classReferenceName);
+                if (classRefDataMaybe.isEmpty()) {
+                    /*
+                     * The referenced dependency class is not available somewhere on the current classpath either.
+                     * This is an exotic case where we've loaded an implant in a JAR on disk and that's not a
+                     * "fat JAR" (a JAR with all of its dependencies included). The implant JAR is probably
+                     * assuming that dependencies are available (aka "provided") at runtime. This is a bold assumption
+                     * for an implant JAR...
+                     * Either way, there's nothing more we can do.
+                     */
+                    log.warning("Could not find referenced dependency class '" + classReferenceName + "'! Skipping. Expect trouble...");
+                    continue;
+                }
+
+                log.fine("Found dependency '" + classReferenceName + "' on current classpath.");
+
+                // Recurse down on the external dependency that's only available on the current classpath
+                accumulator.put(classReferenceName, classRefDataMaybe.get());
+                readAllDependencies(classReferenceName, classRefSourcePathReader, accumulator);
             }
-
-            accumulator.put(classReferenceName, classRawData.get());
-
-            // Recursively go through the whole dependency tree
-            readAllDependencies(classReferenceName, classDataReader, accumulator);
         }
     }
 

--- a/jarplant-lib/src/test/java/io/github/w1th4d/jarplant/ImplantHandlerTests.java
+++ b/jarplant-lib/src/test/java/io/github/w1th4d/jarplant/ImplantHandlerTests.java
@@ -1,12 +1,13 @@
 package io.github.w1th4d.jarplant;
 
-import io.github.w1th4d.jarplant.implants.DummyTestClassImplant;
-import io.github.w1th4d.jarplant.implants.TestClassImplant;
+import io.github.w1th4d.jarplant.implants.*;
 import javassist.bytecode.ClassFile;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -42,6 +43,61 @@ public class ImplantHandlerTests {
     }
 
     @Test
+    public void testGetSourcePathFor_ExternalDependencyClass_ItsJar() throws FileNotFoundException {
+        // Act
+        Path sourcePathFor = ImplantHandlerImpl.getSourcePathFor(ClassFile.class);
+
+        // Assert
+        assertNotNull("Found a code source path.", sourcePathFor);
+        assertTrue("Found a JAR file.", sourcePathFor.toString().endsWith(".jar"));
+        assertTrue("Found the right library.", sourcePathFor.getFileName().toString().startsWith("javassist"));
+    }
+
+    @Test
+    public void testGetSourcePathFor_ExternalDependencyClassByName_ItsJar() throws FileNotFoundException, ClassNameException, ClassNotFoundException {
+        // Arrange
+        String fullName = ClassName.of(ClassFile.class).getFullClassName();
+        ClassName className = ClassName.fromFullClassName(fullName);
+
+        // Act
+        Path sourcePathFor = ImplantHandlerImpl.getSourcePathFor(className);
+
+        // Assert
+        assertNotNull("Found a code source path.", sourcePathFor);
+        assertTrue("Found a JAR file.", sourcePathFor.toString().endsWith(".jar"));
+        assertTrue("Found the right library.", sourcePathFor.getFileName().toString().startsWith("javassist"));
+    }
+
+    @Test
+    public void testGetSourcePathFor_InternalDependencyClass_ItsDirectory() throws IOException {
+        // Act
+        Path sourcePathFor = ImplantHandlerImpl.getSourcePathFor(DummyDependency.class);
+        ClassName dependencyClassName = ClassName.of(DummyDependency.class);
+
+        // Assert
+        assertNotNull("Found a code source path.", sourcePathFor);
+        assertTrue("Found a directory.", Files.isDirectory(sourcePathFor));
+        Path expectedDepClassFilePath = sourcePathFor.resolve(dependencyClassName.getClassFilePath());
+        assertTrue("Found the class file.", Files.exists(expectedDepClassFilePath));
+    }
+
+    @Test
+    public void testGetSourcePathFor_InternalDependencyClassByName_ItsDirectory() throws FileNotFoundException, ClassNameException, ClassNotFoundException {
+        // Arrange
+        String fullName = ClassName.of(DummyDependency.class).getFullClassName();
+        ClassName className = ClassName.fromFullClassName(fullName);
+
+        // Act
+        Path sourcePathFor = ImplantHandlerImpl.getSourcePathFor(className);
+
+        // Assert
+        assertNotNull("Found a code source path.", sourcePathFor);
+        assertTrue("Found a directory.", Files.isDirectory(sourcePathFor));
+        Path expectedDepClassFilePath = sourcePathFor.resolve(className.getClassFilePath());
+        assertTrue("Found the class file.", Files.exists(expectedDepClassFilePath));
+    }
+
+    @Test
     public void testCreateFor_ClassFile_Success() throws IOException {
         // Arrange
         Path testEnv = findTestEnvironmentDir(this.getClass());
@@ -58,7 +114,34 @@ public class ImplantHandlerTests {
     }
 
     @Test
-    public void testFindAndCreateFor_Class_Success() throws IOException, ClassNotFoundException, ImplantException {
+    public void testCreateForJar_FatJar_FoundDependencies() throws IOException, ClassNameException, ClassNotFoundException, ImplantException {
+        // Arrange
+        Path testJarPath = TestHelpers.getJarFileFromResourceFolder("test-implant-class-jar-with-dependencies.jar");
+        ClassName payloadBearingClassName = ClassName.fromFullClassName("io.github.w1th4d.jarplant.implants.TestClassImplant");
+        ClassName expectedInternalDepName = ClassName.of(TestDependencyClass.class);
+
+        // Act
+        ImplantHandler implant = ImplantHandlerImpl.createFromJar(testJarPath, payloadBearingClassName);
+        ClassFile payloadClass = implant.loadFreshRawSpecimen();
+        Map<ClassName, byte[]> dependencies = implant.getDependencies();
+
+        // Assert
+        assertNotNull("Loaded implant class.", payloadClass);
+        assertNotNull("Found dependencies.", dependencies);
+        assertNotEquals("Found some dependency.", 0, dependencies.size());
+        assertTrue("Found internal dependency.", dependencies.containsKey(expectedInternalDepName));
+        for (ClassName dependencyName : dependencies.keySet()) {
+            if (dependencyName.equals(expectedInternalDepName)) {
+                continue;
+            }
+            if (!dependencyName.getPackageName().startsWith("org.apache.commons.io")) {
+                Assert.fail("Dependency found that was not a part of what we expected.");
+            }
+        }
+    }
+
+    @Test
+    public void testFindAndCreateFor_Class_FoundDependencies() throws IOException, ClassNotFoundException, ImplantException {
         // Arrange
         Class<?> clazz = DummyTestClassImplant.class;
 
@@ -66,10 +149,16 @@ public class ImplantHandlerTests {
         ImplantHandler implant = ImplantHandlerImpl.findAndCreateFor(clazz);
         ClassFile specimen = implant.loadFreshRawSpecimen();
         Class<?> loadedClass = runner.load(specimen);
+        Map<ClassName, byte[]> dependencies = implant.getDependencies();
 
         // Assert
         assertNotNull("Loaded implant class.", specimen);
         assertNotNull("JVM managed to load the specimen.", loadedClass);
+        assertNotNull("Found dependencies.", dependencies);
+        assertNotEquals("Found some dependencies.", 0, dependencies.size());
+        assertTrue("Found DummyDependency class.", dependencies.containsKey(ClassName.of(DummyDependency.class)));
+        assertTrue("Found DummySubDependency class.", dependencies.containsKey(ClassName.of(DummySubDependency.class)));
+        assertTrue("Found the external dependency class.", dependencies.containsKey(ClassName.of(ClassFile.class)));
     }
 
     @Test
@@ -99,7 +188,7 @@ public class ImplantHandlerTests {
         ImplantHandlerImpl.findAndCreateFor(tempFile, ClassName.of(DummyTestClassImplant.class));
     }
 
-    @Test(expected = ClassNotFoundException.class)
+    @Test(expected = Exception.class)
     public void testFindAndCreateFor_StdlibClass_NotFound() throws ImplantException, IOException, ClassNotFoundException {
         ImplantHandlerImpl.findAndCreateFor(String.class);
     }

--- a/jarplant-lib/src/test/java/io/github/w1th4d/jarplant/implants/DummyDependency.java
+++ b/jarplant-lib/src/test/java/io/github/w1th4d/jarplant/implants/DummyDependency.java
@@ -1,7 +1,14 @@
 package io.github.w1th4d.jarplant.implants;
 
+import javassist.bytecode.ClassFile;
+
 public class DummyDependency {
+    @SuppressWarnings("unused")
     public static String somethingUseful() {
+        // Use an external dependency class
+        ClassFile something = new ClassFile(false, "Something", null);
+
+        // Use an internal dependency class
         return "This is directly used. + " + DummySubDependency.somethingUseful();
     }
 }

--- a/test-implant-class/pom.xml
+++ b/test-implant-class/pom.xml
@@ -18,6 +18,16 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <dependencies>
+        <!-- It's a bold move to include external dependencies into implants. -->
+        <!-- JarPlant will fail to inject the implant if any of its dependency classes already exist in the target JAR. -->
+        <!-- This POM is for the implant that's only used internally by the tests. Avoid big libraries like this in an actual implant. -->
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.18.0</version>
+        </dependency>
+    </dependencies>
 
     <profiles>
         <profile>
@@ -163,6 +173,87 @@
                                             <version>${project.version}</version>
                                             <type>jar</type>
                                             <classifier>without-debug</classifier>
+                                            <overWrite>true</overWrite>
+                                            <outputDirectory>${project.basedir}/../jarplant-lib/src/test/resources
+                                            </outputDirectory>
+                                        </artifactItem>
+                                    </artifactItems>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <!-- JAR to test using implants packaged as a fat JAR on disk -->
+        <profile>
+            <id>implant-as-jar-on-disk</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <!-- Compile without debugging info for this JAR -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <version>3.13.0</version>
+                        <executions>
+                            <execution>
+                                <id>compile-without-debug-with-deps</id>
+                                <goals>
+                                    <goal>compile</goal>
+                                </goals>
+                                <configuration>
+                                    <compilerArgs>
+                                        <arg>-g:none</arg>
+                                    </compilerArgs>
+                                    <outputDirectory>${project.build.directory}/classes-without-debug-with-deps
+                                    </outputDirectory>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <!-- Make a fat JAR -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-assembly-plugin</artifactId>
+                        <version>3.6.0</version>
+                        <executions>
+                            <execution>
+                                <id>assemble-without-debug-with-deps</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>single</goal>
+                                </goals>
+                                <configuration>
+                                    <descriptorRefs>
+                                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                                    </descriptorRefs>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <!-- Copy the artifact into the resource folder of the jarplant-lib tests (that's what this module is for) -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>copy-without-debug-with-deps</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>copy</goal>
+                                </goals>
+                                <configuration>
+                                    <stripVersion>true</stripVersion>
+                                    <artifactItems>
+                                        <artifactItem>
+                                            <groupId>io.github.w1th4d.jarplant</groupId>
+                                            <artifactId>test-implant-class</artifactId>
+                                            <version>${project.version}</version>
+                                            <type>jar</type>
+                                            <classifier>jar-with-dependencies</classifier>
                                             <overWrite>true</overWrite>
                                             <outputDirectory>${project.basedir}/../jarplant-lib/src/test/resources
                                             </outputDirectory>

--- a/test-implant-class/src/main/java/io/github/w1th4d/jarplant/implants/TestClassImplant.java
+++ b/test-implant-class/src/main/java/io/github/w1th4d/jarplant/implants/TestClassImplant.java
@@ -1,8 +1,15 @@
 package io.github.w1th4d.jarplant.implants;
 
+import org.apache.commons.io.HexDump;
+
+import java.io.IOException;
+
 public class TestClassImplant {
+    @SuppressWarnings("all")
     private static volatile String CONF_STRING = "Original";
+    @SuppressWarnings("all")
     private static volatile boolean CONF_BOOLEAN = false;
+    @SuppressWarnings("all")
     private static volatile int CONF_INT = 1;
 
     /*
@@ -15,6 +22,17 @@ public class TestClassImplant {
     @SuppressWarnings("unused")
     public static String init() {
         Thread.dumpStack();
+
+        // Use something from an internal dependency (ie just another class form this project)
+        TestDependencyClass otherClass = new TestDependencyClass();
+        otherClass.doSomething();
+
+        // Use something from an external dependency
+        try {
+            HexDump.dump(new byte[]{1, 2, 3, 4, 5}, System.out);
+        } catch (IOException ignored) {
+        }
+
         return getConfigDump();
     }
 

--- a/test-implant-class/src/main/java/io/github/w1th4d/jarplant/implants/TestDependencyClass.java
+++ b/test-implant-class/src/main/java/io/github/w1th4d/jarplant/implants/TestDependencyClass.java
@@ -1,0 +1,11 @@
+package io.github.w1th4d.jarplant.implants;
+
+public class TestDependencyClass {
+    public TestDependencyClass() {
+    }
+
+    @SuppressWarnings("all")
+    public String doSomething() {
+        return "Did something";
+    }
+}


### PR DESCRIPTION
JarPlant uses some rather elaborate ways of finding where a class can be found on disk (referred to as _code source path_ in the code). This is necessary to go from a Class reference to an actual `.class` file that can be read and parsed by Javassist. Depending on how JarPlant is invoked, the code source path may be a directory or a JAR.

The changes in this PR makes sure that implants (and their dependencies) can be found and loaded independently of the context in which JarPlant is run. In other words, implants and dependencies can now be found when running from:

- jarplant-cli (standalone JAR)
- An IDE (`target/classes`)
- Maven or JUnit test (`target/test-classes`)

This is necessary for building self-replicating implants.